### PR TITLE
Restore the NumericShims module, use it instead of silgen_name.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
   ],
   targets: [
     .target(name: "Complex", dependencies: ["ElementaryFunctions"]),
-    .target(name: "ElementaryFunctions", dependencies: []),
+    .target(name: "ElementaryFunctions", dependencies: ["NumericsShims"]),
+    .target(name: "NumericsShims", dependencies: []),
     
     .testTarget(name: "ComplexTests", dependencies: ["Complex"]),
     .testTarget(name: "ElementaryFunctionTests", dependencies: ["ElementaryFunctions"]),

--- a/Sources/ElementaryFunctions/ScalarConformances.swift
+++ b/Sources/ElementaryFunctions/ScalarConformances.swift
@@ -10,40 +10,43 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Float: Real {
-  @_silgen_name("cosf") public static func cos(_ x: Float) -> Float
-  @_silgen_name("sinf") public static func sin(_ x: Float) -> Float
-  @_silgen_name("tanf") public static func tan(_ x: Float) -> Float
-  @_silgen_name("acosf") public static func acos(_ x: Float) -> Float
-  @_silgen_name("asinf") public static func asin(_ x: Float) -> Float
-  @_silgen_name("atanf") public static func atan(_ x: Float) -> Float
-  @_silgen_name("coshf") public static func cosh(_ x: Float) -> Float
-  @_silgen_name("sinhf") public static func sinh(_ x: Float) -> Float
-  @_silgen_name("tanhf") public static func tanh(_ x: Float) -> Float
-  @_silgen_name("acoshf") public static func acosh(_ x: Float) -> Float
-  @_silgen_name("asinhf") public static func asinh(_ x: Float) -> Float
-  @_silgen_name("atanhf") public static func atanh(_ x: Float) -> Float
-  @_silgen_name("expf") public static func exp(_ x: Float) -> Float
-  @_silgen_name("expm1f") public static func expMinusOne(_ x: Float) -> Float
-  @_silgen_name("logf") public static func log(_ x: Float) -> Float
-  @_silgen_name("log1pf") public static func log(onePlus x: Float) -> Float
-  @_silgen_name("erff") public static func erf(_ x: Float) -> Float
-  @_silgen_name("erfcf") public static func erfc(_ x: Float) -> Float
-  @_silgen_name("exp2f") public static func exp2(_ x: Float) -> Float
-  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-  @_silgen_name("__exp10f") public static func exp10(_ x: Float) -> Float
-  #endif
-  @_silgen_name("hypotf") public static func hypot(_ x: Float, _ y: Float) -> Float
-  @_silgen_name("tgammaf") public static func gamma(_ x: Float) -> Float
-  @_silgen_name("log2f") public static func log2(_ x: Float) -> Float
-  @_silgen_name("log10f") public static func log10(_ x: Float) -> Float
+// In theory we might be able to get away with using @_silgen_name for these
+// instead of NumericShims and remove a level of (source-only) indirection.
+// However, at present if we do that we get a compiler crash when this module
+// and the Swift platform module are both imported (<rdar://problem/53821031>).
+import NumericsShims
 
-  @usableFromInline @_silgen_name("powf")
-  internal static func libm_pow(_ x: Float, _ y: Float) -> Float
+extension Float: Real {
+  @_transparent public static func cos(_ x: Float) -> Float { return libm_cosf(x) }
+  @_transparent public static func sin(_ x: Float) -> Float { return libm_sinf(x) }
+  @_transparent public static func tan(_ x: Float) -> Float { return libm_tanf(x) }
+  @_transparent public static func acos(_ x: Float) -> Float { return libm_acosf(x) }
+  @_transparent public static func asin(_ x: Float) -> Float { return libm_asinf(x) }
+  @_transparent public static func atan(_ x: Float) -> Float { return libm_atanf(x) }
+  @_transparent public static func cosh(_ x: Float) -> Float { return libm_coshf(x) }
+  @_transparent public static func sinh(_ x: Float) -> Float { return libm_sinhf(x) }
+  @_transparent public static func tanh(_ x: Float) -> Float { return libm_tanhf(x) }
+  @_transparent public static func acosh(_ x: Float) -> Float { return libm_acoshf(x) }
+  @_transparent public static func asinh(_ x: Float) -> Float { return libm_asinhf(x) }
+  @_transparent public static func atanh(_ x: Float) -> Float { return libm_atanhf(x) }
+  @_transparent public static func exp(_ x: Float) -> Float { return libm_expf(x) }
+  @_transparent public static func expMinusOne(_ x: Float) -> Float  { return libm_expm1f(x) }
+  @_transparent public static func log(_ x: Float) -> Float { return libm_logf(x) }
+  @_transparent public static func log(onePlus x: Float) -> Float { return libm_log1pf(x) }
+  @_transparent public static func erf(_ x: Float) -> Float { return libm_erff(x) }
+  @_transparent public static func erfc(_ x: Float) -> Float { return libm_erfcf(x) }
+  @_transparent public static func exp2(_ x: Float) -> Float { return libm_exp2f(x) }
+  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  @_transparent public static func exp10(_ x: Float) -> Float { return libm_exp10f(x) }
+  #endif
+  @_transparent public static func hypot(_ x: Float, _ y: Float) -> Float { return libm_hypotf(x, y) }
+  @_transparent public static func gamma(_ x: Float) -> Float { return libm_tgammaf(x) }
+  @_transparent public static func log2(_ x: Float) -> Float { return libm_log2f(x) }
+  @_transparent public static func log10(_ x: Float) -> Float { return libm_log10f(x) }
   
   @_transparent public static func pow(_ x: Float, _ y: Float) -> Float {
     guard x >= 0 else { return .nan }
-    return libm_pow(x, y)
+    return libm_powf(x, y)
   }
   
   @_transparent public static func pow(_ x: Float, _ n: Int) -> Float {
@@ -51,57 +54,48 @@ extension Float: Real {
     // rounded in conversion to Float. This only effects very extreme cases,
     // so we'll leave it alone for now; however, it gets the sign wrong if
     // it rounds an odd number to an even number, so we should fix it soon.
-    return libm_pow(x, Float(n))
+    return libm_powf(x, Float(n))
   }
   
-  @usableFromInline @_silgen_name("atan2f")
-  internal static func libm_atan2(_ y: Float, _ x: Float) -> Float
-  
   @_transparent public static func atan2(y: Float, x: Float) -> Float {
-    return libm_atan2(y, x)
+    return libm_atan2f(y, x)
   }
 
   #if !os(Windows)
-  @usableFromInline @_silgen_name("lgammaf_r")
-  internal static func libm_lgamma(_ x: Float, _ signgam: UnsafeMutablePointer<Int32>) -> Float
-  
   @_transparent public static func logGamma(_ x: Float) -> Float {
     var dontCare: Int32 = 0
-    return libm_lgamma(x, &dontCare)
+    return libm_lgammaf(x, &dontCare)
   }
   #endif
 }
 
 extension Double: Real {
-  @_silgen_name("cos") public static func cos(_ x: Double) -> Double
-  @_silgen_name("sin") public static func sin(_ x: Double) -> Double
-  @_silgen_name("tan") public static func tan(_ x: Double) -> Double
-  @_silgen_name("acos") public static func acos(_ x: Double) -> Double
-  @_silgen_name("asin") public static func asin(_ x: Double) -> Double
-  @_silgen_name("atan") public static func atan(_ x: Double) -> Double
-  @_silgen_name("cosh") public static func cosh(_ x: Double) -> Double
-  @_silgen_name("sinh") public static func sinh(_ x: Double) -> Double
-  @_silgen_name("tanh") public static func tanh(_ x: Double) -> Double
-  @_silgen_name("acosh") public static func acosh(_ x: Double) -> Double
-  @_silgen_name("asinh") public static func asinh(_ x: Double) -> Double
-  @_silgen_name("atanh") public static func atanh(_ x: Double) -> Double
-  @_silgen_name("exp") public static func exp(_ x: Double) -> Double
-  @_silgen_name("expm1") public static func expMinusOne(_ x: Double) -> Double
-  @_silgen_name("log") public static func log(_ x: Double) -> Double
-  @_silgen_name("log1p") public static func log(onePlus x: Double) -> Double
-  @_silgen_name("erf") public static func erf(_ x: Double) -> Double
-  @_silgen_name("erfc") public static func erfc(_ x: Double) -> Double
-  @_silgen_name("exp2") public static func exp2(_ x: Double) -> Double
+  @_transparent public static func cos(_ x: Double) -> Double { return libm_cos(x) }
+  @_transparent public static func sin(_ x: Double) -> Double { return libm_sin(x) }
+  @_transparent public static func tan(_ x: Double) -> Double { return libm_tan(x) }
+  @_transparent public static func acos(_ x: Double) -> Double { return libm_acos(x) }
+  @_transparent public static func asin(_ x: Double) -> Double { return libm_asin(x) }
+  @_transparent public static func atan(_ x: Double) -> Double { return libm_atan(x) }
+  @_transparent public static func cosh(_ x: Double) -> Double { return libm_cosh(x) }
+  @_transparent public static func sinh(_ x: Double) -> Double { return libm_sinh(x) }
+  @_transparent public static func tanh(_ x: Double) -> Double { return libm_tanh(x) }
+  @_transparent public static func acosh(_ x: Double) -> Double { return libm_acosh(x) }
+  @_transparent public static func asinh(_ x: Double) -> Double { return libm_asinh(x) }
+  @_transparent public static func atanh(_ x: Double) -> Double { return libm_atanh(x) }
+  @_transparent public static func exp(_ x: Double) -> Double { return libm_exp(x) }
+  @_transparent public static func expMinusOne(_ x: Double) -> Double  { return libm_expm1(x) }
+  @_transparent public static func log(_ x: Double) -> Double { return libm_log(x) }
+  @_transparent public static func log(onePlus x: Double) -> Double { return libm_log1p(x) }
+  @_transparent public static func erf(_ x: Double) -> Double { return libm_erf(x) }
+  @_transparent public static func erfc(_ x: Double) -> Double { return libm_erfc(x) }
+  @_transparent public static func exp2(_ x: Double) -> Double { return libm_exp2(x) }
   #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-  @_silgen_name("__exp10") public static func exp10(_ x: Double) -> Double
+  @_transparent public static func exp10(_ x: Double) -> Double { return libm_exp10(x) }
   #endif
-  @_silgen_name("hypot") public static func hypot(_ x: Double, _ y: Double) -> Double
-  @_silgen_name("tgamma") public static func gamma(_ x: Double) -> Double
-  @_silgen_name("log2") public static func log2(_ x: Double) -> Double
-  @_silgen_name("log10") public static func log10(_ x: Double) -> Double
-
-  @usableFromInline @_silgen_name("pow")
-  internal static func libm_pow(_ x: Double, _ y: Double) -> Double
+  @_transparent public static func hypot(_ x: Double, _ y: Double) -> Double { return libm_hypot(x, y) }
+  @_transparent public static func gamma(_ x: Double) -> Double { return libm_tgamma(x) }
+  @_transparent public static func log2(_ x: Double) -> Double { return libm_log2(x) }
+  @_transparent public static func log10(_ x: Double) -> Double { return libm_log10(x) }
   
   @_transparent public static func pow(_ x: Double, _ y: Double) -> Double {
     guard x >= 0 else { return .nan }
@@ -116,75 +110,66 @@ extension Double: Real {
     return libm_pow(x, Double(n))
   }
   
-  @usableFromInline @_silgen_name("atan2")
-  internal static func libm_atan2(_ y: Double, _ x: Double) -> Double
-  
   @_transparent public static func atan2(y: Double, x: Double) -> Double {
     return libm_atan2(y, x)
   }
 
   #if !os(Windows)
-  @usableFromInline @_silgen_name("lgamma_r")
-  internal static func libm_lgamma_r(_ x: Double, _ signgam: UnsafeMutablePointer<Int32>) -> Double
-  
   @_transparent public static func logGamma(_ x: Double) -> Double {
     var dontCare: Int32 = 0
-    return libm_lgamma_r(x, &dontCare)
+    return libm_lgamma(x, &dontCare)
   }
   #endif
 }
 
 #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
 extension Float80: Real {
-  @_silgen_name("cosl") public static func cos(_ x: Float80) -> Float80
-  @_silgen_name("sinl") public static func sin(_ x: Float80) -> Float80
-  @_silgen_name("tanl") public static func tan(_ x: Float80) -> Float80
-  @_silgen_name("acosl") public static func acos(_ x: Float80) -> Float80
-  @_silgen_name("asinl") public static func asin(_ x: Float80) -> Float80
-  @_silgen_name("atanl") public static func atan(_ x: Float80) -> Float80
-  @_silgen_name("coshl") public static func cosh(_ x: Float80) -> Float80
-  @_silgen_name("sinhl") public static func sinh(_ x: Float80) -> Float80
-  @_silgen_name("tanhl") public static func tanh(_ x: Float80) -> Float80
-  @_silgen_name("acoshl") public static func acosh(_ x: Float80) -> Float80
-  @_silgen_name("asinhl") public static func asinh(_ x: Float80) -> Float80
-  @_silgen_name("atanhl") public static func atanh(_ x: Float80) -> Float80
-  @_silgen_name("expl") public static func exp(_ x: Float80) -> Float80
-  @_silgen_name("expm1l") public static func expMinusOne(_ x: Float80) -> Float80
-  @_silgen_name("logl") public static func log(_ x: Float80) -> Float80
-  @_silgen_name("log1pl") public static func log(onePlus x: Float80) -> Float80
-  @_silgen_name("erfl") public static func erf(_ x: Float80) -> Float80
-  @_silgen_name("erfcl") public static func erfc(_ x: Float80) -> Float80
-  @_silgen_name("exp2l") public static func exp2(_ x: Float80) -> Float80
-  @_silgen_name("hypotl") public static func hypot(_ x: Float80, _ y: Float80) -> Float80
-  @_silgen_name("tgammal") public static func gamma(_ x: Float80) -> Float80
-  @_silgen_name("log2l") public static func log2(_ x: Float80) -> Float80
-  @_silgen_name("log10l") public static func log10(_ x: Float80) -> Float80
-
-  @usableFromInline @_silgen_name("powl")
-  internal static func libm_pow(_ x: Float80, _ y: Float80) -> Float80
+  @_transparent public static func cos(_ x: Float80) -> Float80 { return libm_cosl(x) }
+  @_transparent public static func sin(_ x: Float80) -> Float80 { return libm_sinl(x) }
+  @_transparent public static func tan(_ x: Float80) -> Float80 { return libm_tanl(x) }
+  @_transparent public static func acos(_ x: Float80) -> Float80 { return libm_acosl(x) }
+  @_transparent public static func asin(_ x: Float80) -> Float80 { return libm_asinl(x) }
+  @_transparent public static func atan(_ x: Float80) -> Float80 { return libm_atanl(x) }
+  @_transparent public static func cosh(_ x: Float80) -> Float80 { return libm_coshl(x) }
+  @_transparent public static func sinh(_ x: Float80) -> Float80 { return libm_sinhl(x) }
+  @_transparent public static func tanh(_ x: Float80) -> Float80 { return libm_tanhl(x) }
+  @_transparent public static func acosh(_ x: Float80) -> Float80 { return libm_acoshl(x) }
+  @_transparent public static func asinh(_ x: Float80) -> Float80 { return libm_asinhl(x) }
+  @_transparent public static func atanh(_ x: Float80) -> Float80 { return libm_atanhl(x) }
+  @_transparent public static func exp(_ x: Float80) -> Float80 { return libm_expl(x) }
+  @_transparent public static func expMinusOne(_ x: Float80) -> Float80  { return libm_expm1l(x) }
+  @_transparent public static func log(_ x: Float80) -> Float80 { return libm_logl(x) }
+  @_transparent public static func log(onePlus x: Float80) -> Float80 { return libm_log1pl(x) }
+  @_transparent public static func erf(_ x: Float80) -> Float80 { return libm_erfl(x) }
+  @_transparent public static func erfc(_ x: Float80) -> Float80 { return libm_erfcl(x) }
+  @_transparent public static func exp2(_ x: Float80) -> Float80 { return libm_exp2l(x) }
+  @_transparent public static func hypot(_ x: Float80, _ y: Float80) -> Float80 { return libm_hypotl(x, y) }
+  @_transparent public static func gamma(_ x: Float80) -> Float80 { return libm_tgammal(x) }
+  @_transparent public static func log2(_ x: Float80) -> Float80 { return libm_log2l(x) }
+  @_transparent public static func log10(_ x: Float80) -> Float80 { return libm_log10l(x) }
   
   @_transparent public static func pow(_ x: Float80, _ y: Float80) -> Float80 {
     guard x >= 0 else { return .nan }
-    return libm_pow(x, y)
+    return libm_powl(x, y)
   }
   
   @_transparent public static func pow(_ x: Float80, _ n: Int) -> Float80 {
-    return libm_pow(x, Float80(n))
+    // TODO: this implementation is not quite correct, because n may be
+    // rounded in conversion to Float80. This only effects very extreme cases,
+    // so we'll leave it alone for now; however, it gets the sign wrong if
+    // it rounds an odd number to an even number, so we should fix it soon.
+    return libm_powl(x, Float80(n))
   }
-  
-  @usableFromInline @_silgen_name("atan2l")
-  internal static func libm_atan2(_ y: Float80, _ x: Float80) -> Float80
   
   @_transparent public static func atan2(y: Float80, x: Float80) -> Float80 {
-    return libm_atan2(y, x)
+    return libm_atan2l(y, x)
   }
 
-  @usableFromInline @_silgen_name("lgammal_r")
-  internal static func libm_lgamma_r(_ x: Float80, _ signgam: UnsafeMutablePointer<Int32>) -> Float80
-  
+  #if !os(Windows)
   @_transparent public static func logGamma(_ x: Float80) -> Float80 {
     var dontCare: Int32 = 0
-    return libm_lgamma_r(x, &dontCare)
+    return libm_lgammal(x, &dontCare)
   }
+  #endif
 }
 #endif

--- a/Sources/NumericsShims/NumericsShims.c
+++ b/Sources/NumericsShims/NumericsShims.c
@@ -1,0 +1,20 @@
+//===--- NumericsShims.c --------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file exists only to trigger the NumericShims module to build; without
+// it swiftpm won't build anything, and then the shims are not available for
+// the modules that need them.
+
+// If any shims are added that are not pure header inlines, whatever runtime
+// support they require can be added to this file.
+
+#include "NumericsShims.h"

--- a/Sources/NumericsShims/include/NumericsShims.h
+++ b/Sources/NumericsShims/include/NumericsShims.h
@@ -1,0 +1,362 @@
+//===--- NumericsShims.h --------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define HEADER_SHIM static inline __attribute__((__always_inline__))
+
+// MARK: - math functions for float
+
+HEADER_SHIM float libm_cosf(float x) {
+  return __builtin_cosf(x);
+}
+
+HEADER_SHIM float libm_sinf(float x) {
+  return __builtin_sinf(x);
+}
+
+HEADER_SHIM float libm_tanf(float x) {
+  return __builtin_tanf(x);
+}
+
+HEADER_SHIM float libm_acosf(float x) {
+  return __builtin_acosf(x);
+}
+
+HEADER_SHIM float libm_asinf(float x) {
+  return __builtin_asinf(x);
+}
+
+HEADER_SHIM float libm_atanf(float x) {
+  return __builtin_atanf(x);
+}
+
+HEADER_SHIM float libm_coshf(float x) {
+  return __builtin_coshf(x);
+}
+
+HEADER_SHIM float libm_sinhf(float x) {
+  return __builtin_sinhf(x);
+}
+
+HEADER_SHIM float libm_tanhf(float x) {
+  return __builtin_tanhf(x);
+}
+
+HEADER_SHIM float libm_acoshf(float x) {
+  return __builtin_acoshf(x);
+}
+
+HEADER_SHIM float libm_asinhf(float x) {
+  return __builtin_asinhf(x);
+}
+
+HEADER_SHIM float libm_atanhf(float x) {
+  return __builtin_atanhf(x);
+}
+
+HEADER_SHIM float libm_expf(float x) {
+  return __builtin_expf(x);
+}
+
+HEADER_SHIM float libm_expm1f(float x) {
+  return __builtin_expm1f(x);
+}
+
+HEADER_SHIM float libm_logf(float x) {
+  return __builtin_logf(x);
+}
+
+HEADER_SHIM float libm_log1pf(float x) {
+  return __builtin_log1pf(x);
+}
+
+HEADER_SHIM float libm_powf(float x, float y) {
+  return __builtin_powf(x, y);
+}
+
+HEADER_SHIM float libm_atan2f(float y, float x) {
+  return __builtin_atan2f(y, x);
+}
+
+HEADER_SHIM float libm_erff(float x) {
+  return __builtin_erff(x);
+}
+
+HEADER_SHIM float libm_erfcf(float x) {
+  return __builtin_erfcf(x);
+}
+
+HEADER_SHIM float libm_exp2f(float x) {
+  return __builtin_exp2f(x);
+}
+
+#if __APPLE__
+HEADER_SHIM float libm_exp10f(float x) {
+  extern float __exp10f(float);
+  return __exp10f(x);
+}
+#endif
+
+HEADER_SHIM float libm_hypotf(float x, float y) {
+#if defined(_WIN32)
+  extern float _hypotf(float, float);
+  return _hypotf(x, y);
+#else
+  return __builtin_hypotf(x, y);
+#endif
+}
+
+HEADER_SHIM float libm_tgammaf(float x) {
+  return __builtin_tgammaf(x);
+}
+
+HEADER_SHIM float libm_log2f(float x) {
+  return __builtin_log2f(x);
+}
+
+HEADER_SHIM float libm_log10f(float x) {
+  return __builtin_log10f(x);
+}
+
+#if !defined _WIN32
+HEADER_SHIM float libm_lgammaf(float x, int *signp) {
+#if __APPLE__
+  extern float lgammaf_r(float, int *);
+#endif
+  return lgammaf_r(x, signp);
+}
+#endif
+
+// MARK: - math functions for double
+
+HEADER_SHIM double libm_cos(double x) {
+  return __builtin_cos(x);
+}
+
+HEADER_SHIM double libm_sin(double x) {
+  return __builtin_sin(x);
+}
+
+HEADER_SHIM double libm_tan(double x) {
+  return __builtin_tan(x);
+}
+
+HEADER_SHIM double libm_acos(double x) {
+  return __builtin_acos(x);
+}
+
+HEADER_SHIM double libm_asin(double x) {
+  return __builtin_asin(x);
+}
+
+HEADER_SHIM double libm_atan(double x) {
+  return __builtin_atan(x);
+}
+
+HEADER_SHIM double libm_cosh(double x) {
+  return __builtin_cosh(x);
+}
+
+HEADER_SHIM double libm_sinh(double x) {
+  return __builtin_sinh(x);
+}
+
+HEADER_SHIM double libm_tanh(double x) {
+  return __builtin_tanh(x);
+}
+
+HEADER_SHIM double libm_acosh(double x) {
+  return __builtin_acosh(x);
+}
+
+HEADER_SHIM double libm_asinh(double x) {
+  return __builtin_asinh(x);
+}
+
+HEADER_SHIM double libm_atanh(double x) {
+  return __builtin_atanh(x);
+}
+
+HEADER_SHIM double libm_exp(double x) {
+  return __builtin_exp(x);
+}
+
+HEADER_SHIM double libm_expm1(double x) {
+  return __builtin_expm1(x);
+}
+
+HEADER_SHIM double libm_log(double x) {
+  return __builtin_log(x);
+}
+
+HEADER_SHIM double libm_log1p(double x) {
+  return __builtin_log1p(x);
+}
+
+HEADER_SHIM double libm_pow(double x, double y) {
+  return __builtin_pow(x, y);
+}
+
+HEADER_SHIM double libm_atan2(double y, double x) {
+  return __builtin_atan2(y, x);
+}
+
+HEADER_SHIM double libm_erf(double x) {
+  return __builtin_erf(x);
+}
+
+HEADER_SHIM double libm_erfc(double x) {
+  return __builtin_erfc(x);
+}
+
+HEADER_SHIM double libm_exp2(double x) {
+  return __builtin_exp2(x);
+}
+
+#if __APPLE__
+HEADER_SHIM double libm_exp10(double x) {
+  extern double __exp10(double);
+  return __exp10(x);
+}
+#endif
+
+HEADER_SHIM double libm_hypot(double x, double y) {
+  return __builtin_hypot(x, y);
+}
+
+HEADER_SHIM double libm_tgamma(double x) {
+  return __builtin_tgamma(x);
+}
+
+HEADER_SHIM double libm_log2(double x) {
+  return __builtin_log2(x);
+}
+
+HEADER_SHIM double libm_log10(double x) {
+  return __builtin_log10(x);
+}
+
+#if !defined _WIN32
+HEADER_SHIM double libm_lgamma(double x, int *signp) {
+#if __APPLE__
+  extern double lgamma_r(double, int *);
+#endif
+  return lgamma_r(x, signp);
+}
+#endif
+
+// MARK: - math functions for float80
+#if !defined _WIN32 && (defined __i386__ || defined __x86_64__)
+HEADER_SHIM long double libm_cosl(long double x) {
+  return __builtin_cosl(x);
+}
+
+HEADER_SHIM long double libm_sinl(long double x) {
+  return __builtin_sinl(x);
+}
+
+HEADER_SHIM long double libm_tanl(long double x) {
+  return __builtin_tanl(x);
+}
+
+HEADER_SHIM long double libm_acosl(long double x) {
+  return __builtin_acosl(x);
+}
+
+HEADER_SHIM long double libm_asinl(long double x) {
+  return __builtin_asinl(x);
+}
+
+HEADER_SHIM long double libm_atanl(long double x) {
+  return __builtin_atanl(x);
+}
+
+HEADER_SHIM long double libm_coshl(long double x) {
+  return __builtin_coshl(x);
+}
+
+HEADER_SHIM long double libm_sinhl(long double x) {
+  return __builtin_sinhl(x);
+}
+
+HEADER_SHIM long double libm_tanhl(long double x) {
+  return __builtin_tanhl(x);
+}
+
+HEADER_SHIM long double libm_acoshl(long double x) {
+  return __builtin_acoshl(x);
+}
+
+HEADER_SHIM long double libm_asinhl(long double x) {
+  return __builtin_asinhl(x);
+}
+
+HEADER_SHIM long double libm_atanhl(long double x) {
+  return __builtin_atanhl(x);
+}
+
+HEADER_SHIM long double libm_expl(long double x) {
+  return __builtin_expl(x);
+}
+
+HEADER_SHIM long double libm_expm1l(long double x) {
+  return __builtin_expm1l(x);
+}
+
+HEADER_SHIM long double libm_logl(long double x) {
+  return __builtin_logl(x);
+}
+
+HEADER_SHIM long double libm_log1pl(long double x) {
+  return __builtin_log1pl(x);
+}
+
+HEADER_SHIM long double libm_powl(long double x, long double y) {
+  return __builtin_powl(x, y);
+}
+
+HEADER_SHIM long double libm_atan2l(long double y, long double x) {
+  return __builtin_atan2l(y, x);
+}
+
+HEADER_SHIM long double libm_erfl(long double x) {
+  return __builtin_erfl(x);
+}
+
+HEADER_SHIM long double libm_erfcl(long double x) {
+  return __builtin_erfcl(x);
+}
+
+HEADER_SHIM long double libm_exp2l(long double x) {
+  return __builtin_exp2l(x);
+}
+
+HEADER_SHIM long double libm_hypotl(long double x, long double y) {
+  return __builtin_hypotl(x, y);
+}
+
+HEADER_SHIM long double libm_tgammal(long double x) {
+  return __builtin_tgammal(x);
+}
+
+HEADER_SHIM long double libm_log2l(long double x) {
+  return __builtin_log2l(x);
+}
+
+HEADER_SHIM long double libm_log10l(long double x) {
+  return __builtin_log10l(x);
+}
+
+HEADER_SHIM long double libm_lgammal(long double x, int *signp) {
+  extern long double lgammal_r(long double, int *);
+  return lgammal_r(x, signp);
+}
+#endif


### PR DESCRIPTION
I had thought that we could get away with just using @_silgen_name to wrap the platform libm functions in ElementaryFunctions conformances, but that's now failing in release builds when both ElementaryFunctions and the Platform module are imported (and actually crashing swiftc).

Fall back on the previous strategy of using C header shims. This adds an extra layer of source abstraction, but we're still able to optimize it away at compile time, even in unoptimized builds, so we can live with it for now.