### PR TITLE
Beef up complex multiply/divide testing, fix an edge-case.

### DIFF
--- a/Sources/Complex/Complex.swift
+++ b/Sources/Complex/Complex.swift
@@ -220,6 +220,28 @@ extension Complex {
     guard isFinite else { return .infinity }
     return max(abs(x), abs(y))
   }
+  
+  /// A "canonical" representation of the value.
+  ///
+  /// For normal complex numbers with a RealType conforming to
+  /// BinaryFloatingPoint (the common case), the result is simply this value
+  /// unmodified. For zeros, the result has the representation (+0, +0). For
+  /// infinite values, the result has the representation (+inf, +0).
+  ///
+  /// If the RealType admits non-canonical representations, the x and y
+  /// components are canonicalized in the result.
+  ///
+  /// This is mainly useful for interoperation with other languages, where
+  /// you may want to reduce each equivalence class to a single representative
+  /// before passing across langauge boundaries, but it may also be useful
+  /// for some serialization tasks. It's also a useful implementation detail for
+  /// some primitive operations.
+  @inlinable
+  public var canonicalized: Self {
+    if isZero { return .zero }
+    if isFinite { return self.multiplied(by: 1) }
+    return .infinity
+  }
 }
 
 // MARK: - Additional Initializers


### PR DESCRIPTION
Previously we simply checked if the result of the naive divide was normal; this isn't quite right, because it could miss unsafeLengthSquared underflowing without going all the way to zero, resulting in significant loss of intermediate precision. Instead check if unsafeLengthSquared itself is non-normal. This is actually a cheaper check, and gets us everything we need, so it's a win-win.

Proof: if `w.unsafeLengthSquared` is normal, then so is `w.conjugate.divided(by: unsafeLengthSquared)` (because its magnitude is the square root of the former quantity), which means that we're left only with the multiply. Our goal is to be only as good as multiply is, so that's good enough.