### PR TITLE
Further benchmark improvments, workaround hypot bug.

### DIFF
--- a/Sources/Complex/Arithmetic.swift
+++ b/Sources/Complex/Arithmetic.swift
@@ -94,8 +94,12 @@ extension Complex: Numeric {
   }
   
   @usableFromInline
+  @_specialize(where RealType == Float)
+  @_specialize(where RealType == Double)
   internal static func rescaledDivide(_ z: Complex, _ w: Complex) -> Complex {
     if z.isZero || !w.isFinite { return .zero }
+    // TODO: detect when RealType is Float and just promote to Double, then
+    // use the naive algorithm.
     let zScale = z.magnitude
     let wScale = w.magnitude
     let zNorm = z.divided(by: zScale)


### PR DESCRIPTION
Added benchmark version that defeats hoisting part of the divide computation outside of the workloop (but kept the old ones as well, because *both* are good representitives of what we want to track). Also found a bug in macOS hypot very close to the overflow boundary for the naive algorithm, and added a workaround (also reported the bug).