### PR TITLE
Add '.xcodesamplecode.plist' file to achieve proper markdown rendering

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
Add '.xcodesamplecode.plist' file to achieve proper markdown rendering within Xcode, e.g. of README

As seen in [Apple's ARKit demo (inside `/ARKitExample.xcodeproj/` directory)](https://developer.apple.com/sample-code/wwdc/2017/PlacingObjects.zip)

### Before:
<img width="1792" alt="without___xcodesamplecode_plist___we_get_no_markdown_rendering" src="https://user-images.githubusercontent.com/864410/68436754-2dfa9680-01bf-11ea-91ba-e4cd3e0ed321.png">

### After:
<img width="1792" alt="with___xcodesamplecode_plist___we_get_proper_markdown_rendering" src="https://user-images.githubusercontent.com/864410/68436755-318e1d80-01bf-11ea-9eed-f77ef2087153.png">

