### PR TITLE
Added LinuxMain.swift so numerics can be used on Linux

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import ComplexTests
+@testable import RealTests
+
+XCTMain([
+    testCase(ArithmeticBenchmarkTests.testDivisionByConstant),
+    testCase(ArithmeticBenchmarkTests.testReciprocal),
+    testCase(ArithmeticBenchmarkTests.testDivisionByConstantC),
+    testCase(ArithmeticBenchmarkTests.testMultiplication),
+    testCase(ArithmeticBenchmarkTests.testMultiplicationC),
+    testCase(ArithmeticBenchmarkTests.testDivision),
+    testCase(ArithmeticBenchmarkTests.testDivisionC),
+    testCase(ArithmeticBenchmarkTests.testDivisionPoorScaling),
+    testCase(ArithmeticBenchmarkTests.testDivisionPoorScalingC),
+    testCase(ArithmeticBenchmarkTests.testMultiplicationPoorScaling),
+    testCase(ArithmeticBenchmarkTests.testMultiplicationPoorScalingC),
+    testCase(PropertyTests.testProperties),
+    testCase(PropertyTests.testEquatableHashable),
+    testCase(ArithmeticTests.testPolar),
+    testCase(ArithmeticTests.testBaudinSmith),
+    testCase(RealTests.testFloat),
+    testCase(RealTests.testDouble),
+    testCase(RealTests.testFloat80)
+])


### PR DESCRIPTION
Wanting to use this library on Linux, running `swift run --repl` fails because `LinuxMain.swift` is not  present under the Tests directory. Adding this file allows the library to work on Linux.