### PR TITLE
Fixed `Complex` division by zero to return .infinity

### DIFF
--- a/Sources/Complex/Arithmetic.swift
+++ b/Sources/Complex/Arithmetic.swift
@@ -90,6 +90,7 @@ extension Complex: Numeric {
   
   @usableFromInline @_alwaysEmitIntoClient @inline(never)
   internal static func rescaledDivide(_ z: Complex, _ w: Complex) -> Complex {
+    if w.isZero { return .infinity }
     if z.isZero || !w.isFinite { return .zero }
     // TODO: detect when RealType is Float and just promote to Double, then
     // use the naive algorithm.

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -181,5 +181,7 @@ final class ArithmeticTests: XCTestCase {
   func testDivisionByZero() {
     XCTAssertFalse((Complex(0, 0) / Complex(0, 0)).isFinite)
     XCTAssertFalse((Complex(1, 1) / Complex(0, 0)).isFinite)
+    XCTAssertFalse((Complex.infinity / Complex(0, 0)).isFinite)
+    XCTAssertFalse((Complex.i / Complex(0, 0)).isFinite)
   }
 }

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -177,4 +177,9 @@ final class ArithmeticTests: XCTestCase {
       if checkMultiply(test.b, test.c, expected: test.a, ulps: 1.0) { XCTFail() }
     }
   }
+
+  func testDivisionByZero() {
+    XCTAssertFalse((Complex(0, 0) / Complex(0, 0)).isFinite)
+    XCTAssertFalse((Complex(1, 1) / Complex(0, 0)).isFinite)
+  }
 }


### PR DESCRIPTION
This should address the bug detailed by issue [#54](https://github.com/apple/swift-numerics/issues/54).