### PR TITLE
Remove broken link in Real module readme

### DIFF
--- a/Sources/Real/README.md
+++ b/Sources/Real/README.md
@@ -2,7 +2,7 @@
 
 [SE-0246] proposed an API for "basic math functions" that would make operations like sine and logarithm available in generic contexts.
 It was accepted, but because of limitations in the compiler, the API could not be added to the standard library in a source-stable manner.
-The `Real` [module][Real] provides that API as a separate module so that you can use it right away to get access to the improved API for these operations in your projects.
+The `Real` module provides that API as a separate module so that you can use it right away to get access to the improved API for these operations in your projects.
 
 ## Protocols and Methods
 


### PR DESCRIPTION
The link target for `[Real]` wasn't defined. I decided toremove the link altogether because the readme would essentially link to itself.

Let me know if you'd rather keep the link (presumably it should link to <https://github.com/apple/swift-numerics/tree/master/Sources/Real>?).