### PR TITLE
Address behavior of Complex.init(length:phase:)

### DIFF
--- a/Sources/Complex/Complex.swift
+++ b/Sources/Complex/Complex.swift
@@ -472,7 +472,7 @@ extension Complex {
     (length, phase)
   }
   
-  /// A complex value specified with  polar coordinates.
+  /// Creates a complex value specified with polar coordinates.
   ///
   /// Edge cases:
   /// -

--- a/Sources/Complex/Complex.swift
+++ b/Sources/Complex/Complex.swift
@@ -472,26 +472,39 @@ extension Complex {
     (length, phase)
   }
   
-  /// Constructs a complex value from polar coordinates.
+  /// A complex value specified with  polar coordinates.
   ///
   /// Edge cases:
   /// -
-  /// If the phase is non-finite, but length is finite, this initializer
-  /// fails and returns nil. In all other cases, a non-nil value is constructed.
+  /// - Negative lengths are interpreted as reflecting the point through the origin, i.e.:
+  ///   ```
+  ///   Complex(length: -r, phase: θ) == -Complex(length: r, phase: θ)
+  ///   ```
+  /// - For any `θ`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Complex(length: .zero, phase: θ) == .zero
+  ///   ```
+  /// - For any `θ`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Complex(length: .infinity, phase: θ) == .infinity
+  ///   ```
+  /// - Otherwise, `θ` must be finite, or a precondition failure occurs.
   ///
   /// See also:
   /// -
   /// - `.length`
   /// - `.phase`
   /// - `.polar`
-  public init?(length: RealType, phase: RealType) {
-    guard phase.isFinite else {
-      // There's no way to make sense of finite magnitude and non-finite phase.
-      if length.isFinite { return nil }
-      // r is infinite so phase doesn't matter.
-      self = .infinity
-      return
+  @inlinable
+  public init(length: RealType, phase: RealType) {
+    if phase.isFinite {
+      self = Complex(.cos(phase), .sin(phase)).multiplied(by: length)
+    } else {
+      precondition(
+        length == 0 || length == .infinity,
+        "Either phase must be finite, or length must be zero or infinity."
+      )
+      self = Complex(length)
     }
-    self.init(length * .cos(phase), length * .sin(phase))
   }
 }

--- a/Tests/ComplexTests/ArithmeticBenchmarkTests.swift
+++ b/Tests/ComplexTests/ArithmeticBenchmarkTests.swift
@@ -28,7 +28,7 @@ extension Complex where RealType == Double {
 
 let wellScaledDoubles: [Complex<Double>] = (0 ..< 1024).map { _ in
   Complex(length: Double.random(in: 0.5 ..< 2.0),
-          phase: Double.random(in: -.pi ..< .pi))!
+          phase: Double.random(in: -.pi ..< .pi))
 }
 
 let poorlyScaledDoubles: [Complex<Double>] = (0 ..< 1024).map { _ in
@@ -37,7 +37,7 @@ let poorlyScaledDoubles: [Complex<Double>] = (0 ..< 1024).map { _ in
                    exponent: .random(in: -970 ... 1023),
                    significand: .random(in: 1 ..< 2)),
     phase: Double.random(in: -.pi ..< .pi)
-  )!
+  )
 }
 
 final class ArithmeticBenchmarkTests: XCTestCase {

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -63,6 +63,17 @@ final class ArithmeticTests: XCTestCase {
   func testPolar<T>(_ type: T.Type)
   where T: BinaryFloatingPoint, T: Real,
         T.Exponent: FixedWidthInteger, T.RawSignificand: FixedWidthInteger {
+    
+    // In order to support round-tripping from rectangular to polar coordinate
+    // systems, as a special case phase can be non-finite when length is
+    // either zero or infinity.
+    XCTAssertEqual(Complex<T>(length: .zero, phase:  .infinity), .zero)
+    XCTAssertEqual(Complex<T>(length: .zero, phase: -.infinity), .zero)
+    XCTAssertEqual(Complex<T>(length: .zero, phase:  .nan     ), .zero)
+    XCTAssertEqual(Complex<T>(length: .infinity, phase:  .infinity), .infinity)
+    XCTAssertEqual(Complex<T>(length: .infinity, phase: -.infinity), .infinity)
+    XCTAssertEqual(Complex<T>(length: .infinity, phase:  .nan     ), .infinity)
+          
     let exponentRange =
       (T.leastNormalMagnitude.exponent + T.Exponent(T.significandBitCount)) ...
         T.greatestFiniteMagnitude.exponent
@@ -81,7 +92,7 @@ final class ArithmeticTests: XCTestCase {
       // this is good--more test coverage!--and bad, because without tight
       // bounds on every platform's libm, we can't get tight bounds on the
       // accuracy of these operations, so we need to relax them gradually).
-      let z = Complex(length: p.length, phase: p.phase)!
+      let z = Complex(length: p.length, phase: p.phase)
       if !closeEnough(z.length, p.length, ulps: 16) {
         print("p = \(p)\nz = \(z)\nz.length = \(z.length)")
         XCTFail()
@@ -90,6 +101,13 @@ final class ArithmeticTests: XCTestCase {
         print("p = \(p)\nz = \(z)\nz.phase = \(z.phase)")
         XCTFail()
       }
+      // Complex(length: -r, phase: θ) = -Complex(length: r, phase: θ).
+      let w = Complex(length: -p.length, phase: p.phase)
+      if w != -z {
+        print("p = \(p)\nw = \(w)\nz = \(z)")
+        XCTFail()
+      }
+      XCTAssertEqual(w, -z)
       // if length*length is normal, it should be unsafeLengthSquared, up
       // to small error.
       if (p.length*p.length).isNormal {
@@ -99,14 +117,14 @@ final class ArithmeticTests: XCTestCase {
         }
       }
       // Test reciprocal and normalized:
-      let r = Complex(length: 1/p.length, phase: -p.phase)!
+      let r = Complex(length: 1/p.length, phase: -p.phase)
       if r.isNormal {
         if relativeError(r, z.reciprocal!) > 16 {
           print("p = \(p)\nz = \(z)\nz.reciprocal = \(r)")
           XCTFail()
         }
       } else { XCTAssertNil(z.reciprocal) }
-      let n = Complex(length: 1, phase: p.phase)!
+      let n = Complex(length: 1, phase: p.phase)
       if relativeError(n, z.normalized!) > 16 {
         print("p = \(p)\nz = \(z)\nz.normalized = \(n)")
         XCTFail()
@@ -114,10 +132,10 @@ final class ArithmeticTests: XCTestCase {
       
       // Now test multiplication and division using the polar inputs:
       for q in inputs {
-        let w = Complex(length: q.length, phase: q.phase)!
-        let product = Complex(length: p.length * q.length, phase: p.phase + q.phase)!
+        let w = Complex(length: q.length, phase: q.phase)
+        let product = Complex(length: p.length * q.length, phase: p.phase + q.phase)
         if checkMultiply(z, w, expected: product, ulps: 16) { XCTFail() }
-        let quotient = Complex(length: p.length / q.length, phase: p.phase - q.phase)!
+        let quotient = Complex(length: p.length / q.length, phase: p.phase - q.phase)
         if checkDivide(z, w, expected: quotient, ulps: 16) { XCTFail() }
       }
     }


### PR DESCRIPTION
Instead of being failable, adopt the following policy:

- If length is zero or infinity, the phase does not matter.
- Otherwise, the phase must be finite or a precondition failure occurs.

Note that this is a source-breaking change.

Discussed here: https://github.com/apple/swift-numerics/issues/51