### PR TITLE
AlgebraicField should conform to SignedNumeric, not just Numeric.

### DIFF
--- a/Sources/Complex/Arithmetic.swift
+++ b/Sources/Complex/Arithmetic.swift
@@ -165,5 +165,3 @@ extension Complex: AlgebraicField {
     return nil
   }
 }
-
-extension Complex: SignedNumeric {}

--- a/Sources/Complex/README.md
+++ b/Sources/Complex/README.md
@@ -7,7 +7,7 @@ This module provides a `Complex` number type generic over an underlying `RealTyp
 ```
 This module provides approximate feature parity and memory layout compatibility with C, Fortran, and C++ complex types (although the importer cannot map the types for you, buffers may be reinterpreted to shim API defined in other languages).
 
-The usual arithmetic operators are provided for Complex numbers, as well as conversion to and from polar coordinates and many useful properties, plus conformances to the obvious usual protocols: `Equatable`, `Hashable`, `Codable` (if the underlying `RealType` is), and `AlgebraicField` (hence also `AdditiveArithmetic` and `Numeric`).
+The usual arithmetic operators are provided for Complex numbers, as well as conversion to and from polar coordinates and many useful properties, plus conformances to the obvious usual protocols: `Equatable`, `Hashable`, `Codable` (if the underlying `RealType` is), and `AlgebraicField` (hence also `AdditiveArithmetic` and `SignedNumeric`).
 
 ### Dependencies:
 - The `Real` module.

--- a/Sources/Real/AlgebraicField.swift
+++ b/Sources/Real/AlgebraicField.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type modeling an algebraic [field]. Refines the `Numeric` protocol,
+/// A type modeling an algebraic [field]. Refines the `SignedNumeric` protocol,
 /// adding division.
 ///
 /// A field is a set on which addition, subtraction, multiplication, and
@@ -40,11 +40,12 @@
 /// See Also:
 /// -
 /// - Real
+/// - SignedNumeric
 /// - Numeric
 /// - AdditiveArithmetic
 ///
 /// [field]: https://en.wikipedia.org/wiki/Field_(mathematics)
-public protocol AlgebraicField: Numeric {
+public protocol AlgebraicField: SignedNumeric {
   
   static func /=(a: inout Self, b: Self)
   

--- a/Sources/Real/README.md
+++ b/Sources/Real/README.md
@@ -28,7 +28,8 @@ The `RealFunctions` protocol refines `ElementaryFunctions`, and adds operations 
 The protocol that you will use most often is `Real`, which describes a floating-point type equipped with the full set of basic math functions.
 This is a great protocol to use in writing generic code, because it has all the basics that you need to implement most numeric functions.
 
-The fourth protocol is `AlgebraicField`, which `Real` also refines. This protocol is a very small refinement of `Numeric`, adding the `/` and `/=` operators and a `reciprocal` property.
+The fourth protocol is `AlgebraicField`, which `Real` also refines.
+This protocol is a very small refinement of `SignedNumeric`, adding the `/` and `/=` operators and a `reciprocal` property.
 The primary use of this protocol is for writing code that is generic over real and complex types.
 
 ## Using Real


### PR DESCRIPTION
Because a field necessarily has additive inverses, SignedNumeric conformance is appropriate. (SignedNumeric is poorly named; it doesn't actually mean that a type has a "sign", only that there's a negation operation: https://bugs.swift.org/browse/SR-12078.)