### PR TITLE
build: add initial CMake based build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+cmake_minimum_required(VERSION 3.16)
+project(swift-numerics
+  LANGUAGES Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+include(SwiftSupport)
+
+add_subdirectory(Sources)
+
+get_property(SWIFT_NUMERICS_EXPORTS GLOBAL PROPERTY SWIFT_NUMERICS_EXPORTS)
+export(TARGETS ${SWIFT_NUMERICS_EXPORTS}
+  NAMESPACE SwiftNumerics::
+  FILE swift-numerics-config.cmake
+  EXPORT_LINK_INTERFACE_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,13 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
+include(CTest)
 include(SwiftSupport)
 
 add_subdirectory(Sources)
+if(BUILD_TESTING)
+  add_subdirectory(Tests)
+endif()
 
 get_property(SWIFT_NUMERICS_EXPORTS GLOBAL PROPERTY SWIFT_NUMERICS_EXPORTS)
 export(TARGETS ${SWIFT_NUMERICS_EXPORTS}

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,13 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_subdirectory(_NumericsShims)
+add_subdirectory(ComplexModule)
+add_subdirectory(Numerics)
+add_subdirectory(RealModule)

--- a/Sources/ComplexModule/CMakeLists.txt
+++ b/Sources/ComplexModule/CMakeLists.txt
@@ -1,0 +1,21 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(ComplexModule
+  Arithmetic.swift
+  Complex.swift
+  Differentiable.swift)
+set_target_properties(ComplexModule PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(ComplexModule PUBLIC
+  RealModule)
+
+
+_install_target(ComplexModule)
+set_property(GLOBAL APPEND PROPERTY SWIFT_NUMERICS_EXPORTS ComplexModule)

--- a/Sources/Numerics/CMakeLists.txt
+++ b/Sources/Numerics/CMakeLists.txt
@@ -1,0 +1,20 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(Numerics
+  Numerics.swift)
+set_target_properties(Numerics PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(Numerics PUBLIC
+  ComplexModule
+  RealModule)
+
+
+_install_target(Numerics)
+set_property(GLOBAL APPEND PROPERTY SWIFT_NUMERICS_EXPORTS Numerics)

--- a/Sources/RealModule/CMakeLists.txt
+++ b/Sources/RealModule/CMakeLists.txt
@@ -1,0 +1,25 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(RealModule
+  AlgebraicField.swift
+  Double+Real.swift
+  ElementaryFunctions.swift
+  Float+Real.swift
+  Float80+Real.swift
+  Real.swift
+  RealFunctions.swift)
+set_target_properties(RealModule PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_link_libraries(RealModule PUBLIC
+  _NumericsShims)
+
+
+_install_target(RealModule)
+set_property(GLOBAL APPEND PROPERTY SWIFT_NUMERICS_EXPORTS RealModule)

--- a/Sources/_NumericsShims/CMakeLists.txt
+++ b/Sources/_NumericsShims/CMakeLists.txt
@@ -1,0 +1,14 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(_NumericsShims INTERFACE)
+target_include_directories(_NumericsShims INTERFACE
+  include)
+
+set_property(GLOBAL APPEND PROPERTY SWIFT_NUMERICS_EXPORTS _NumericsShims)

--- a/Sources/_NumericsShims/include/module.modulemap
+++ b/Sources/_NumericsShims/include/module.modulemap
@@ -1,0 +1,3 @@
+module _NumericsShims {
+  header "_NumericsShims.h"
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+find_package(dispatch CONFIG QUIET)
+find_package(Foundation CONFIG QUIET)
+find_package(XCTest CONFIG QUIET)
+
+add_subdirectory(ComplexTests)
+add_subdirectory(RealTests)
+
+add_executable(SwiftNumericsTestRunner
+  WindowsMain.swift)
+target_link_libraries(SwiftNumericsTestRunner PRIVATE
+  ComplexTests
+  RealTests)
+
+add_test(NAME SwiftNumericsTestRunner
+  COMMAND SwiftNumericsTestRunner)

--- a/Tests/ComplexTests/CMakeLists.txt
+++ b/Tests/ComplexTests/CMakeLists.txt
@@ -1,0 +1,21 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(ComplexTests
+  ArithmeticTests.swift
+  DifferentiableTests.swift
+  PropertyTests.swift)
+set_target_properties(ComplexTests PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+target_compile_options(ComplexTests PRIVATE
+  -enable-testing)
+target_link_libraries(ComplexTests PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  ComplexModule
+  XCTest)

--- a/Tests/RealTests/CMakeLists.txt
+++ b/Tests/RealTests/CMakeLists.txt
@@ -1,0 +1,19 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+add_library(RealTests
+  IntegerExponentTests.swift
+  RealTests.swift
+  RealTestSupport.swift)
+target_compile_options(RealTests PRIVATE
+  -enable-testing)
+target_link_libraries(RealTests PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  RealModule
+  XCTest)

--- a/Tests/WindowsMain.swift
+++ b/Tests/WindowsMain.swift
@@ -1,0 +1,76 @@
+//===--- WindowsMain.swift ------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if os(Windows)
+import XCTest
+
+@testable
+import RealTests
+
+@testable
+import ComplexTests
+
+extension ElementaryFunctionChecks {
+  static var all = testCase([
+    ("testFloat", ElementaryFunctionChecks.testFloat),
+    ("testDouble", ElementaryFunctionChecks.testDouble),
+  ])
+}
+
+extension IntegerExponentTests {
+  static var all = testCase([
+    ("testFloat", IntegerExponentTests.testFloat),
+    ("testDouble", IntegerExponentTests.testDouble),
+  ])
+}
+
+extension ArithmeticTests {
+  static var all = testCase([
+    ("testPolar", ArithmeticTests.testPolar),
+    ("testBaudinSmith", ArithmeticTests.testBaudinSmith),
+    ("testDivisionByZero", ArithmeticTests.testDivisionByZero),
+  ])
+}
+
+#if canImport(_Differentiation)
+  extension DifferentiableTests {
+    static var all = testCase([
+      ("testComponentGetter", DifferentiableTests.testComponentGetter),
+      ("testConjugate",  DifferentiableTests.testConjugate),
+      ("testArithmetics", DifferentiableTests.testArithmetics),
+    ])
+  }
+#endif
+
+extension PropertyTests {
+  static var all = testCase([
+    ("testProperties", PropertyTests.testProperties),
+    ("testEquatableHashable", PropertyTests.testEquatableHashable),
+    ("testCodable", PropertyTests.testCodable),
+  ])
+}
+
+var testCases = [
+  ElementaryFunctionChecks.all,
+  IntegerExponentTests.all,
+  ArithmeticTests.all,
+  PropertyTests.all,
+]
+
+#if canImport(_Differentiation)
+testCases += [
+  DifferentiableTests.all
+]
+#endif
+
+XCTMain(testCases)
+
+#endif

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,84 @@
+#[[
+This source file is part of the Swift Numerics open source project
+
+Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+#]]
+
+# Returns the architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# Sets ${result_var_name} with the converted architecture name derived from
+# CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(${result_var_name} macosx PARENT_SCOPE)
+  else()
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} cmake_system_name_lc)
+    set(${result_var_name} ${cmake_system_name_lc} PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(_install_target module)
+  get_swift_host_arch(swift_arch)
+  get_swift_host_os(swift_os)
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}
+    LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}
+    RUNTIME DESTINATION bin)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module}.swiftdoc
+      DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/${mmodule}.swiftmodule
+      RENAME ${swift_arch}.swiftdoc)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module}.swiftmodule
+      DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/${mmodule}.swiftmodule
+      RENAME ${swift_arch}.swiftmodule)
+  else()
+    install(FILES
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module}.swiftdoc
+      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module}.swiftmodule
+      DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/${swift_arch})
+  endif()
+endfunction()


### PR DESCRIPTION
This adds a CMake based build, which enables the build of swift-numerics
on Windows.  This currently does not add the test suite to the build as
there are still some issues to work out in building the full test suite
which require additional math operations to fully build.