### PR TITLE
[Sketch] Quaternion Module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
   products: [
     .library(name: "ComplexModule", targets: ["ComplexModule"]),
     .library(name: "Numerics", targets: ["Numerics"]),
+    .library(name: "QuaternionModule", targets: ["QuaternionModule"]),
     .library(name: "RealModule", targets: ["RealModule"]),
   ],
   dependencies: [
@@ -25,9 +26,11 @@ let package = Package(
     .target(name: "ComplexModule", dependencies: ["RealModule"]),
     .target(name: "Numerics", dependencies: ["ComplexModule", "RealModule"]),
     .target(name: "_NumericsShims", dependencies: []),
+    .target(name: "QuaternionModule", dependencies: ["RealModule"]),
     .target(name: "RealModule", dependencies: ["_NumericsShims"]),
     
     .testTarget(name: "ComplexTests", dependencies: ["ComplexModule", "_NumericsShims"]),
+    .testTarget(name: "QuaternionTests", dependencies: ["QuaternionModule"]),
     .testTarget(name: "RealTests", dependencies: ["RealModule"]),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Questions about how to use Swift Numerics modules, or issues that are not clearl
 ## Modules
 1. [RealModule](Sources/RealModule/README.md)
 2. [ComplexModule](Sources/ComplexModule/README.md)
+3. [QuaternionModule](Sources/QuaternionModule/README.md)
 
 ## Future expansion
 1. [Approximate Equality](https://github.com/apple/swift-numerics/issues/3)

--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -1,0 +1,172 @@
+//===--- Arithmetic.swift -------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import RealModule
+
+// MARK: - Conformance to Additive Arithmetic
+extension Quaternion: AdditiveArithmetic {
+  @_transparent
+  public static func + (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
+    Quaternion(from: lhs.components + rhs.components)
+  }
+
+  @_transparent
+  public static func - (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
+    Quaternion(from: lhs.components - rhs.components)
+  }
+
+  @_transparent
+  public static func += (lhs: inout Quaternion, rhs: Quaternion) {
+    lhs = lhs + rhs
+  }
+
+  @_transparent
+  public static func -= (lhs: inout Quaternion, rhs: Quaternion) {
+    lhs = lhs - rhs
+  }
+}
+
+// MARK: - Vector space structure
+//
+// See: https://github.com/apple/swift-numerics/issues/12
+// While the issue tackles Complex operations, this should be in sync with Quaternions
+extension Quaternion {
+  @usableFromInline @_transparent
+  internal func multiplied(by scalar: Component) -> Quaternion {
+    Quaternion(from: components * scalar)
+  }
+
+  @usableFromInline @_transparent
+  internal func divided(by scalar: Component) -> Quaternion {
+    Quaternion(from: components / scalar)
+  }
+}
+
+// MARK: - Multiplicative structure
+extension Quaternion: AlgebraicField {
+    
+  @_transparent
+  public static func * (lhs: Self, rhs: Self) -> Quaternion {
+
+    let a = (lhs.components * SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)).sum()
+    let b = (lhs.components * SIMD4(+rhs.components.x, -rhs.components.y, -rhs.components.z, -rhs.components.w)).sum()
+    let c = (lhs.components * SIMD4(+rhs.components.y, +rhs.components.x, +rhs.components.w, -rhs.components.z)).sum()
+    let d = (lhs.components * SIMD4(+rhs.components.z, -rhs.components.w, +rhs.components.x, +rhs.components.y)).sum()
+
+    return Quaternion(from: SIMD4(a,b,c,d))
+  }
+
+  @_transparent
+  public static func / (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
+    // Try the naive expression lhs/rhs = lhs*conj(rhs) / |rhs|^2; if we can compute
+    // this without over/underflow, everything is fine and the result is
+    // correct. If not, we have to rescale and do the computation carefully.
+    let lenSq = rhs.lengthSquared
+    guard lenSq.isNormal else { return rescaledDivide(lhs, rhs) }
+    return lhs * (rhs.conjugate.divided(by: lenSq))
+  }
+
+  @_transparent
+  public static func *= (lhs: inout Quaternion, rhs: Quaternion) {
+    lhs = lhs * rhs
+  }
+
+  @_transparent
+  public static func /= (lhs: inout Quaternion, rhs: Quaternion) {
+    lhs = lhs / rhs
+  }
+
+  @usableFromInline @_alwaysEmitIntoClient @inline(never)
+  internal static func rescaledDivide(_ lhs: Quaternion, _ rhs: Quaternion) -> Quaternion {
+    if rhs.isZero { return .infinity }
+    if lhs.isZero || !rhs.isFinite { return .zero }
+    // TODO: detect when RealType is Float and just promote to Double, then
+    // use the naive algorithm.
+    let lhsScale = lhs.magnitude
+    let rhsScale = rhs.magnitude
+    let lhsNorm = lhs.divided(by: lhsScale)
+    let rhsNorm = rhs.divided(by: rhsScale)
+    let r = (lhsNorm * rhsNorm.conjugate).divided(by: rhsNorm.lengthSquared)
+    // At this point, the result is (r * lhsScale)/rhsScale computed without
+    // undue overflow or underflow. We know that r is close to unity, so
+    // the question is simply what order in which to do this computation
+    // to avoid spurious overflow or underflow. There are three options
+    // to choose from:
+    //
+    // - r * (lhsScale / rhsScale)
+    // - (r * lhsScale) / rhsScale
+    // - (r / rhsScale) * lhsScale
+    //
+    // The simplest case is when lhsScale / rhsScale is normal:
+    if (lhsScale / rhsScale).isNormal {
+      return r.multiplied(by: lhsScale / rhsScale)
+    }
+    // Otherwise, we need to compute either rNorm * lhsScale or rNorm / rhsScale
+    // first. Choose the first if the first scaling behaves well, otherwise
+    // choose the other one.
+    if (r.magnitude * lhsScale).isNormal {
+      return r.multiplied(by: lhsScale).divided(by: rhsScale)
+    }
+    return r.divided(by: rhsScale).multiplied(by: lhsScale)
+  }
+
+  /// A normalized quaternion with the same direction and phase as this value.
+  ///
+  /// If such a value cannot be produced, `nil` is returned.
+  @inlinable
+  public var normalized: Quaternion? {
+    if length.isNormal {
+      return divided(by: length)
+    }
+    if isZero || !isFinite {
+      return nil
+    }
+    return divided(by: magnitude).normalized
+  }
+
+  /// The inverse of this quaternion.
+  /// 
+  /// If such a value cannot be produced, `nil` is returned.
+  @_transparent
+  public var inverse: Self? {
+    if lengthSquared.isNormal {
+      return conjugate.divided(by: lengthSquared)
+    }
+    return nil
+  }
+
+  /// The reciprocal of this value, if it can be computed without undue overflow or underflow.
+  ///
+  /// If z.reciprocal is non-nil, you can safely replace division by z with multiplication by this
+  /// value. It is not advantageous to do this for an isolated division, but if you are dividing
+  /// many values by a single denominator, this will often be a significant performance win.
+  ///
+  /// Typical use looks like this:
+  /// ```
+  /// func divide<T: Real>(data: [Quaternion<T>], by divisor: Quaternion<T>) -> [Quaternion<T>] {
+  ///   // If divisor is well-scaled, use multiply by reciprocal.
+  ///   if let recip = divisor.reciprocal {
+  ///     return data.map { $0 * recip }
+  ///   }
+  ///   // Fallback on using division.
+  ///   return data.map { $0 / divisor }
+  /// }
+  /// ```
+  @inlinable
+  public var reciprocal: Quaternion? {
+    let recip = 1/self
+    if recip.isNormal || isZero || !isFinite {
+      return recip
+    }
+    return nil
+  }
+}
+

--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -55,10 +55,10 @@ extension Quaternion: AlgebraicField {
   @_transparent
   public static func * (lhs: Self, rhs: Self) -> Quaternion {
 
-    let rhsA = SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)
-    let rhsB = SIMD4(+rhs.components.x, -rhs.components.y, -rhs.components.z, -rhs.components.w)
-    let rhsC = SIMD4(+rhs.components.y, +rhs.components.x, +rhs.components.w, -rhs.components.z)
-    let rhsD = SIMD4(+rhs.components.z, -rhs.components.w, +rhs.components.x, +rhs.components.y)
+    let rhsA = SIMD4(+rhs.components.x, -rhs.components.y, -rhs.components.z, -rhs.components.w)
+    let rhsB = SIMD4(+rhs.components.y, +rhs.components.x, +rhs.components.w, -rhs.components.z)
+    let rhsC = SIMD4(+rhs.components.z, -rhs.components.w, +rhs.components.x, +rhs.components.y)
+    let rhsD = SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)
 
     let a = (lhs.components * rhsA).sum()
     let b = (lhs.components * rhsB).sum()

--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -53,7 +53,7 @@ extension Quaternion {
 // MARK: - Multiplicative structure
 extension Quaternion: AlgebraicField {
   @_transparent
-  public static func * (lhs: Self, rhs: Self) -> Quaternion {
+  public static func * (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
 
     let rhsA = SIMD4(+rhs.components.x, -rhs.components.y, -rhs.components.z, -rhs.components.w)
     let rhsB = SIMD4(+rhs.components.y, +rhs.components.x, +rhs.components.w, -rhs.components.z)

--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -55,17 +55,17 @@ extension Quaternion: AlgebraicField {
   @_transparent
   public static func * (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
 
-    let rhsA = SIMD4(+rhs.components.x, -rhs.components.y, -rhs.components.z, -rhs.components.w)
-    let rhsB = SIMD4(+rhs.components.y, +rhs.components.x, +rhs.components.w, -rhs.components.z)
-    let rhsC = SIMD4(+rhs.components.z, -rhs.components.w, +rhs.components.x, +rhs.components.y)
-    let rhsD = SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)
+    let rhsX = SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)
+    let rhsY = SIMD4(-rhs.components.z, +rhs.components.w, +rhs.components.x, +rhs.components.y)
+    let rhsZ = SIMD4(+rhs.components.y, -rhs.components.x, +rhs.components.w, +rhs.components.z)
+    let rhsR = SIMD4(-rhs.components.x, -rhs.components.y, -rhs.components.z, +rhs.components.w)
 
-    let a = (lhs.components * rhsA).sum()
-    let b = (lhs.components * rhsB).sum()
-    let c = (lhs.components * rhsC).sum()
-    let d = (lhs.components * rhsD).sum()
+    let x = (lhs.components * rhsX).sum()
+    let y = (lhs.components * rhsY).sum()
+    let z = (lhs.components * rhsZ).sum()
+    let r = (lhs.components * rhsR).sum()
 
-    return Quaternion(from: SIMD4(a,b,c,d))
+    return Quaternion(from: SIMD4(x,y,z,r))
   }
 
   @_transparent

--- a/Sources/QuaternionModule/Norms.swift
+++ b/Sources/QuaternionModule/Norms.swift
@@ -29,7 +29,7 @@
 //   a square root.
 //
 // - There exist finite values `q` for which the Euclidean norm is not
-//   representable (consider the quaternion with `a`, `b`, `c` and `d` all
+//   representable (consider the quaternion with `r`, `x`, `y` and `z` all
 //   equal to `RealType.greatestFiniteMagnitude`; the Euclidean norm is
 //   `.sqrt(4) * .greatestFiniteMagnitude`, which overflows).
 //
@@ -38,7 +38,7 @@
 // which makes it the obvious choice to bind `.magnitude`.
 extension Quaternion {
 
-  /// The ∞-norm of the value (`max(abs(a), abs(b), abs(c), abs(d))`).
+  /// The ∞-norm of the value (`max(abs(r), abs(x), abs(y), abs(z))`).
   ///
   /// If you need the Euclidean norm (a.k.a. 2-norm) use the `length` or `lengthSquared`
   /// properties instead.
@@ -59,7 +59,7 @@ extension Quaternion {
     return max(abs(components.max()), abs(components.min()))
   }
 
-  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(a*a + b*b + c*c + d*d)`).
+  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(r*r + x*x + y*y + z*z)`).
   ///
   /// This value is highly prone to overflow or underflow.
   ///
@@ -81,7 +81,7 @@ extension Quaternion {
     return .sqrt(lengthSquared)
   }
 
-  /// The squared length `(a*a + b*b + c*c + d*d)`.
+  /// The squared length `(r*r + x*x + y*y + z*z)`.
   ///
   /// This value is highly prone to overflow or underflow.
   /// 

--- a/Sources/QuaternionModule/Norms.swift
+++ b/Sources/QuaternionModule/Norms.swift
@@ -1,0 +1,101 @@
+//===--- Norms.swift ------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// Norms and related quantities defined for Quaternion.
+//
+// The following API are provided by this extension:
+//
+//   var magnitude: RealType     // infinity norm
+//   var length: RealType        // Euclidean norm
+//   var lengthSquared: RealType // Euclidean norm squared
+//
+// For detailed documentation, consult Norms.md or the inline documentation
+// for each operation.
+//
+// Implementation notes:
+//
+// `.magnitude` does not bind the Euclidean norm; it binds the infinity norm
+// instead. There are two reasons for this choice:
+//
+// - It's simply faster to compute in general, because it does not require
+//   a square root.
+//
+// - There exist finite values `q` for which the Euclidean norm is not
+//   representable (consider the quaternion with `a`, `b`, `c` and `d` all
+//   equal to `RealType.greatestFiniteMagnitude`; the Euclidean norm is
+//   `.sqrt(4) * .greatestFiniteMagnitude`, which overflows).
+//
+// The infinity norm is unique among the common vector norms in having
+// the property that every finite vector has a representable finite norm,
+// which makes it the obvious choice to bind `.magnitude`.
+extension Quaternion {
+
+  /// The ∞-norm of the value (`max(abs(a), abs(b), abs(c), abs(d))`).
+  ///
+  /// If you need the Euclidean norm (a.k.a. 2-norm) use the `length` or `lengthSquared`
+  /// properties instead.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If `q` is not finite, `q.magnitude` is `.infinity`.
+  /// - If `q` is zero, `q.magnitude` is `0`.
+  /// - Otherwise, `q.magnitude` is finite and non-zero.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.lengthSquared`
+  @_transparent
+  public var magnitude: RealType {
+    guard isFinite else { return .infinity }
+    return max(abs(components.max()), abs(components.min()))
+  }
+
+  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(a*a + b*b + c*c + d*d)`).
+  ///
+  /// This value is highly prone to overflow or underflow.
+  ///
+  /// For most use cases, you can use the cheaper `.magnitude`
+  /// property (which computes the ∞-norm) instead, which always produces
+  /// a representable result.
+  ///
+  /// Edge cases:
+  /// -
+  /// If a quaternion is not finite, its `.length` is `infinity`.
+  ///
+  /// See also:
+  /// -
+  /// - `.magnitude`
+  /// - `.lengthSquared`
+  @_transparent
+  public var length: RealType {
+    guard isFinite else { return .infinity }
+    return .sqrt(lengthSquared)
+  }
+
+  /// The squared length `(a*a + b*b + c*c + d*d)`.
+  ///
+  /// This value is highly prone to overflow or underflow.
+  /// 
+  /// For many cases, `.magnitude` can be used instead, which is similarly
+  /// cheap to compute and always returns a representable value.
+  ///
+  /// This property is more efficient to compute than `length`.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.magnitude`
+  @_transparent
+  public var lengthSquared: RealType {
+    (components * components).sum()
+  }
+}

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -1,0 +1,499 @@
+//===--- Quaternion.swift -------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import RealModule
+
+/// A quaternion represented by a real and three imaginary parts.
+///
+/// TODO: More informations on type
+///
+/// Implementation notes:
+/// -
+///
+/// `.magnitude` does not return the Euclidean norm; it uses the "infinity
+/// norm" (`max(|a|,|b|,|c|,|d|)`) instead. There are two reasons for this
+/// choice: first, it's simply faster to compute on most hardware. Second,
+/// there exist values for which the Euclidean norm cannot be represented.
+/// Using the infinity norm avoids this problem entirely without significant
+/// downsides. You can access the Euclidean norm using the `length` property.
+/// See `Complex` type of the swift-numerics package for additional details.
+public struct Quaternion<RealType> where RealType: Real & SIMDScalar {
+
+  /// The components of the 4-dimensional vector space of the quaternion.
+  ///
+  /// Components are stored within a 4-dimensional SIMD vector with the scalar component
+  /// first, i.e. representing the most common mathmatical representation that is:
+  ///
+  ///     a + bi + cj + dk
+  @usableFromInline @inline(__always)
+  internal var components: SIMD4<RealType>
+
+  /// Creates a new quaternion from given 4-dimensional vector.
+  ///
+  /// This initializer creates a new quaternion by reading the values of the vector as components
+  /// of the quaternion with the scalar component ordered first, i.e in the form of:
+  ///
+  ///     a + bi + cj + dk
+  ///
+  /// - Parameter components: The components of the 4-dimensionsal vector space of the quaternion,
+  /// scalar part first.
+  @_transparent
+  public init(from components: SIMD4<RealType>) {
+    self.components = components
+  }
+}
+
+// MARK: - Basic Property
+extension Quaternion {
+  /// The real part of this quaternion value.
+  public var real: RealType {
+    @_transparent
+    _read { yield components[0] }
+
+    @_transparent
+    _modify { yield &components[0] }
+  }
+
+  /// The imaginary part of this quaternion value.
+  public var imaginary: SIMD3<RealType> {
+    @_transparent
+    get { components[SIMD3(1,2,3)] }
+
+    @_transparent
+    set {
+        components[1] = newValue[0]
+        components[2] = newValue[1]
+        components[3] = newValue[2]
+    }
+  }
+
+  /// The additive identity, with real and imaginary parts all zero.
+  ///
+  /// See also:
+  /// -
+  /// - .one
+  /// - .i
+  /// - .infinity
+  @_transparent
+  public static var zero: Quaternion {
+    .init(0)
+  }
+
+  /// The multiplicative identity, with real part one and imaginary parts all zero.
+  ///
+  /// See also:
+  /// -
+  /// - .zero
+  /// - .i
+  /// - .infinity
+  @_transparent
+  public static var one: Quaternion {
+    .init(1)
+  }
+
+  /// The imaginary unit.
+  ///
+  /// See also:
+  /// -
+  /// - .zero
+  /// - .one
+  /// - .infinity
+  @_transparent
+  public static var i: Quaternion {
+    .init(imaginary: SIMD3(repeating: 1))
+  }
+
+  /// The point at infinity.
+  ///
+  /// See also:
+  /// -
+  /// - .zero
+  /// - .one
+  /// - .i
+  @_transparent
+  public static var infinity: Quaternion {
+    .init(.infinity)
+  }
+
+  /// The conjugate of this quaternion value.
+  @_transparent
+  public var conjugate: Quaternion {
+    .init(from: components.replacing(with: -components, where: [false, true, true, true]))
+  }
+
+  /// True if this value is finite.
+  ///
+  /// A quaternion value is finite if neither component is infinity or nan.
+  ///
+  /// See also:
+  /// -
+  /// - `.isNormal`
+  /// - `.isSubnormal`
+  /// - `.isZero`
+  /// - `.isPure`
+  @_transparent
+  public var isFinite: Bool {
+    components.x.isFinite
+        && components.y.isFinite
+        && components.z.isFinite
+        && components.w.isFinite
+  }
+
+  /// True if this value is normal.
+  ///
+  /// A quaternion is normal if it is finite and *either* the real or imaginary component is normal.
+  /// A floating-point number representing one of the components is normal if its exponent allows a
+  /// full-precision representation.
+  ///
+  /// See also:
+  /// -
+  /// - `.isFinite`
+  /// - `.isSubnormal`
+  /// - `.isZero`
+  /// - `.isPure`
+  @_transparent
+  public var isNormal: Bool {
+    isFinite && (
+        real.isNormal || (imaginary.x.isNormal && imaginary.y.isNormal && imaginary.z.isNormal)
+    )
+  }
+
+  /// True if this value is subnormal.
+  ///
+  /// A quaternion is subnormal if it is finite, not normal, and not zero. When the result of a
+  /// computation is subnormal, underflow has occurred and the result generally does not have full
+  /// precision.
+  ///
+  /// See also:
+  /// -
+  /// - `.isFinite`
+  /// - `.isNormal`
+  /// - `.isZero`
+  /// - `.isPure`
+  @_transparent
+  public var isSubnormal: Bool {
+    isFinite && !isNormal && !isZero
+  }
+
+  /// True if this value is zero.
+  ///
+  /// A quaternion is zero if *both* the real and imaginary components are zero.
+  ///
+  /// See also:
+  /// -
+  /// - `.isFinite`
+  /// - `.isNormal`
+  /// - `.isSubnormal`
+  /// - `.isPure`
+  @_transparent
+  public var isZero: Bool {
+    return components.x.isZero
+        && components.y.isZero
+        && components.z.isZero
+        && components.w.isZero
+  }
+
+  /// True if this value is only defined by the imaginary part (`real == .zero`)
+  @_transparent
+  public var isPure: Bool {
+    real.isZero
+  }
+
+  /// The ∞-norm of the value (`max(abs(real), abs(imaginary))`).
+  ///
+  /// If you need the Euclidean norm (a.k.a. 2-norm) use the `length` or `lengthSquared`
+  /// properties instead.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If `z` is not finite, `z.magnitude` is `.infinity`.
+  /// - If `z` is zero, `z.magnitude` is `0`.
+  /// - Otherwise, `z.magnitude` is finite and non-zero.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.lengthSquared`
+  @_transparent
+  public var magnitude: RealType {
+    guard isFinite else { return .infinity }
+    return max(abs(components.max()), abs(components.min()))
+  }
+}
+
+// MARK: - Additional Initializers
+extension Quaternion {
+  /// The quaternion with specified real part and zero imaginary part.
+  ///
+  /// Equivalent to `Quaternion(real, SIMD3(repeating: 0))`.
+  @inlinable
+  public init(_ real: RealType) {
+    self.init(real, SIMD3(repeating: 0))
+  }
+
+  /// The quaternion with specified imaginary part and zero real part.
+  ///
+  /// Equivalent to `Quaternion(0, imaginary)`.
+  @inlinable
+  public init(imaginary: SIMD3<RealType>) {
+    self.init(0, imaginary)
+  }
+
+  /// The quaternion with specified imaginary part and zero real part.
+  ///
+  /// Equivalent to `Quaternion(0, imaginary)`.
+  @inlinable
+  public init(imaginary: (b: RealType, c: RealType, d: RealType)) {
+    self.init(imaginary: SIMD3(imaginary.b, imaginary.c, imaginary.d))
+  }
+
+  /// The quaternion with specified real part and imaginary parts.
+  @inlinable
+  public init(_ real: RealType, _ imaginary: SIMD3<RealType>) {
+    self.init(from: SIMD4(real, imaginary.x, imaginary.y, imaginary.z))
+  }
+
+  /// The quaternion with specified real part and imaginary parts.
+  @inlinable
+  public init(_ real: RealType, _ imaginary: (b: RealType, c: RealType, d: RealType)) {
+    self.init(real, SIMD3(imaginary.b, imaginary.c, imaginary.d))
+  }
+
+  /// The quaternion with specified real part and zero imaginary part.
+  ///
+  /// Equivalent to `Quaternion(RealType(real))`.
+  @inlinable
+  public init<Other: BinaryInteger>(_ real: Other) {
+    self.init(RealType(real))
+  }
+
+  /// The quaternion with specified real part and zero imaginary part,
+  /// if it can be constructed without rounding.
+  @inlinable
+  public init?<Other: BinaryInteger>(exactly real: Other) {
+    guard let real = RealType(exactly: real) else { return nil }
+    self.init(real)
+  }
+
+  public typealias IntegerLiteralType = Int
+
+  @inlinable
+  public init(integerLiteral value: Int) {
+    self.init(RealType(value))
+  }
+}
+
+extension Quaternion where RealType: BinaryFloatingPoint {
+  /// `other` rounded to the nearest representable value of this type.
+  @inlinable
+  public init<Other: BinaryFloatingPoint>(_ other: Quaternion<Other>) {
+    self.init(from: SIMD4(
+        RealType(other.components.x),
+        RealType(other.components.y),
+        RealType(other.components.z),
+        RealType(other.components.w)
+    ))
+  }
+
+  /// `other`, if it can be represented exactly in this type; otherwise `nil`.
+  @inlinable
+  public init?<Other: BinaryFloatingPoint>(exactly other: Quaternion<Other>) {
+    guard
+        let x = RealType(exactly: other.components.x),
+        let y = RealType(exactly: other.components.y),
+        let z = RealType(exactly: other.components.z),
+        let w = RealType(exactly: other.components.w)
+    else { return nil }
+    self.init(from: SIMD4(x, y, z, w))
+  }
+}
+
+// MARK: - Conformance to Hashable and Equatable
+extension Quaternion: Hashable {
+
+  @_transparent
+  public static func == (lhs: Quaternion, rhs: Quaternion) -> Bool {
+    // Identify all numbers with either component non-finite as a single "point at infinity".
+    guard lhs.isFinite || rhs.isFinite else { return true }
+    // For finite numbers, equality is defined componentwise. Cases where
+    // only one of a or b is infinite fall through to here as well, but this
+    // expression correctly returns false for them so we don't need to handle
+    // them explicitly.
+    return lhs.components == rhs.components
+  }
+
+  @_transparent
+  public func hash(into hasher: inout Hasher) {
+    // There are two equivalence classes to which we owe special attention:
+    // All zeros should hash to the same value, regardless of sign, and all
+    // non-finite numbers should hash to the same value, regardless of
+    // representation. The correct behavior for zero falls out for free from
+    // the hash behavior of floating-point, but we need to use a
+    // representative member for any non-finite values.
+    if isFinite {
+      hasher.combine(components.x)
+      hasher.combine(components.y)
+      hasher.combine(components.z)
+      hasher.combine(components.w)
+    } else {
+      hasher.combine(RealType.infinity)
+    }
+  }
+}
+
+// MARK: - Conformance to Codable
+// FloatingPoint does not refine Codable, so this is a conditional conformance.
+extension Quaternion: Decodable where RealType: Decodable {
+  public init(from decoder: Decoder) throws {
+    var unkeyedContainer = try decoder.unkeyedContainer()
+    self.init(from: try unkeyedContainer.decode(SIMD4<RealType>.self))
+  }
+}
+
+extension Quaternion: Encodable where RealType: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    try components.encode(to: encoder)
+  }
+}
+
+// MARK: - Formatting
+extension Quaternion: CustomStringConvertible {
+  public var description: String {
+    guard isFinite else { return "inf" }
+    return "(\(components.x), \(components.y), \(components.z), \(components.w))"
+  }
+}
+
+extension Quaternion: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    "Quaternion<\(RealType.self)>\(description)"
+  }
+}
+
+// MARK: - Operations for working with polar form
+extension Quaternion {
+
+  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(lengthSquared)`).
+  ///
+  /// Note that it *is* possible for this property to overflow,
+  /// because `lengthSquared` is highly prone to overflow or underflow.
+  ///
+  /// For most use cases, you can use the cheaper `.magnitude`
+  /// property (which computes the ∞-norm) instead, which always produces
+  /// a representable result.
+  ///
+  /// Edge cases:
+  /// -
+  /// If a complex value is not finite, its `.length` is `infinity`.
+  ///
+  /// See also:
+  /// -
+  /// - `.magnitude`
+  /// - `.lengthSquared`
+  /// - `.phase`
+  /// - `.polar`
+  /// - `init(r:θ:)`
+  @_transparent
+  public var length: RealType {
+    return .sqrt(lengthSquared)
+  }
+
+  /// The squared length `(real*real + (imaginary*imaginary).sum())`.
+  ///
+  /// This property is more efficient to compute than `length`.
+  ///
+  /// This value is highly prone to overflow or underflow.
+  /// For many cases, `.magnitude` can be used instead, which is similarly
+  /// cheap to compute and always returns a representable value.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.magnitude`
+  @_transparent
+  public var lengthSquared: RealType {
+    (components * components).sum()
+  }
+
+  // MARK: - TODO: .altitude, .azimuth, .polar & .init(length:altitude:azimuth:) -
+
+  /// The altitude (angle).
+  ///
+  /// Edge cases:
+  /// -
+  /// If the quaternion is zero or non-finite, phase is `nan`.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.polar`
+  /// - `init(length:altitude:azimuth:)`
+//  @inlinable
+//  public var altitude: RealType
+
+  /// The azimuth (angle).
+  ///
+  /// Edge cases:
+  /// -
+  /// If the quaternion is zero or non-finite, phase is `nan`.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.polar`
+  /// - `init(length:altitude:azimuth:)`
+//  @inlinable
+//  public var azimuth: RealType
+
+  /// The length, altitude and azimuth (or polar coordinates) of this value.
+  ///
+  /// Edge cases:
+  /// -
+  /// If the quaternion is zero or non-finite, phase is `.nan`.
+  /// If the quaternion is non-finite, length is `.infinity`.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.altitude`
+  /// - `.azimuth`
+  /// - `init(length:altitude:azimuth:)`
+//  public var polar: (length: RealType, altitude: RealType, azimuth: RealType) {
+//    (length, altitude, azimuth)
+//  }
+
+  /// Creates a complex value specified with polar coordinates.
+  ///
+  /// Edge cases:
+  /// -
+  /// - Negative lengths are interpreted as reflecting the point through the origin, i.e.:
+  ///   ```
+  ///   Complex(length: -r, phase: θ) == -Complex(length: r, phase: θ)
+  ///   ```
+  /// - For any `θ`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Complex(length: .zero, phase: θ) == .zero
+  ///   ```
+  /// - For any `θ`, even `.infinity` or `.nan`, if `r` is infinite then:
+  ///   ```
+  ///   Complex(length: r, phase: θ) == .infinity
+  ///   ```
+  /// - Otherwise, `θ` must be finite, or a precondition failure occurs.
+  ///
+  /// See also:
+  /// -
+  /// - `.length`
+  /// - `.altitude`
+  /// - `.azimuth`
+  /// - `.polar`
+//  @inlinable
+//  public init(length: RealType, altitude: RealType, azimuth: RealType)
+}

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -77,9 +77,7 @@ extension Quaternion {
 
     @_transparent
     set {
-        components[1] = newValue[0]
-        components[2] = newValue[1]
-        components[3] = newValue[2]
+      components = SIMD4(components[0], newValue.x, newValue.y, newValue.z)
     }
   }
 

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -204,10 +204,7 @@ extension Quaternion {
   /// - `.isPure`
   @_transparent
   public var isZero: Bool {
-    return components.x.isZero
-        && components.y.isZero
-        && components.z.isZero
-        && components.w.isZero
+    components == .zero
   }
 
   /// True if this value is only defined by the imaginary part (`real == .zero`)

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -357,8 +357,7 @@ extension Quaternion: Hashable {
 // FloatingPoint does not refine Codable, so this is a conditional conformance.
 extension Quaternion: Decodable where RealType: Decodable {
   public init(from decoder: Decoder) throws {
-    var unkeyedContainer = try decoder.unkeyedContainer()
-    self.init(from: try unkeyedContainer.decode(SIMD4<RealType>.self))
+    try self.init(from: SIMD4(from: decoder))
   }
 }
 
@@ -410,6 +409,7 @@ extension Quaternion {
   /// - `.lengthSquared`
   @_transparent
   public var length: RealType {
+    guard isFinite else { return .infinity }
     return .sqrt(lengthSquared)
   }
 

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -43,10 +43,10 @@ public struct Quaternion<RealType> where RealType: Real & SIMDScalar {
   @usableFromInline @inline(__always)
   internal var components: SIMD4<RealType>
 
-  /// A quaternion constructed from given 4-dimensional vector.
+  /// A quaternion constructed from given 4-dimensional SIMD vector.
   ///
   /// Creates a new quaternion by reading the values of the SIMD vector
-  /// as components of a quaternion with teh scalar part first, i.e. in the form of:
+  /// as components of a quaternion with the scalar part first, i.e. in the form of:
   ///
   ///     a + bi + cj + dk
   @usableFromInline @inline(__always)

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -49,8 +49,8 @@ public struct Quaternion<RealType> where RealType: Real & SIMDScalar {
   /// as components of a quaternion with teh scalar part first, i.e. in the form of:
   ///
   ///     a + bi + cj + dk
-  @_transparent
-  public init(from components: SIMD4<RealType>) {
+  @usableFromInline @inline(__always)
+  internal init(from components: SIMD4<RealType>) {
     self.components = components
   }
 }
@@ -83,7 +83,7 @@ extension Quaternion {
     }
   }
 
-  /// The additive identity, with real and imaginary parts all zero.
+  /// The additive identity, with real and *all* imaginary parts zero.
   ///
   /// See also:
   /// -
@@ -95,7 +95,7 @@ extension Quaternion {
     Quaternion(from: SIMD4(repeating: 0))
   }
 
-  /// The multiplicative identity, with real part one and imaginary parts all zero.
+  /// The multiplicative identity, with real part one and *all* imaginary parts zero.
   ///
   /// See also:
   /// -
@@ -149,7 +149,7 @@ extension Quaternion {
   /// - `.isPure`
   @_transparent
   public var isFinite: Bool {
-    components.x.isFinite
+    return components.x.isFinite
         && components.y.isFinite
         && components.z.isFinite
         && components.w.isFinite
@@ -157,9 +157,9 @@ extension Quaternion {
 
   /// True if this value is normal.
   ///
-  /// A quaternion is normal if it is finite and *either* the real or imaginary component is normal.
-  /// A floating-point number representing one of the components is normal if its exponent allows a
-  /// full-precision representation.
+  /// A quaternion is normal if it is finite and *either* the real or *all* of the imaginary
+  /// components are normal. A floating-point number representing one of the components is normal
+  /// if its exponent allows a full-precision representation.
   ///
   /// See also:
   /// -
@@ -169,9 +169,9 @@ extension Quaternion {
   /// - `.isPure`
   @_transparent
   public var isNormal: Bool {
-    isFinite && (
-        real.isNormal || (imaginary.x.isNormal && imaginary.y.isNormal && imaginary.z.isNormal)
-    )
+    let realIsNormal = components.x.isNormal
+    let imaginaryIsNormal = components.y.isNormal && components.z.isNormal && components.w.isNormal
+    return isFinite && (realIsNormal || imaginaryIsNormal)
   }
 
   /// True if this value is subnormal.
@@ -193,7 +193,7 @@ extension Quaternion {
 
   /// True if this value is zero.
   ///
-  /// A quaternion is zero if *both* the real and imaginary components are zero.
+  /// A quaternion is zero if the real and *all* imaginary components are zero.
   ///
   /// See also:
   /// -

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -11,7 +11,7 @@
 
 import RealModule
 
-/// A quaternion represented by a real (or scalar) and three imaginary (or vector) parts.
+/// A quaternion represented by a real (or scalar) part and three imaginary (or vector) parts.
 ///
 /// TODO: introductory text on quaternions
 ///

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -214,27 +214,6 @@ extension Quaternion {
   public var isPure: Bool {
     real.isZero
   }
-
-  /// The ∞-norm of the value (`max(abs(a), abs(b), abs(c), abs(d))`).
-  ///
-  /// If you need the Euclidean norm (a.k.a. 2-norm) use the `length` or `lengthSquared`
-  /// properties instead.
-  ///
-  /// Edge cases:
-  /// -
-  /// - If `q` is not finite, `q.magnitude` is `.infinity`.
-  /// - If `q` is zero, `q.magnitude` is `0`.
-  /// - Otherwise, `q.magnitude` is finite and non-zero.
-  ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.lengthSquared`
-  @_transparent
-  public var magnitude: RealType {
-    guard isFinite else { return .infinity }
-    return max(abs(components.max()), abs(components.min()))
-  }
 }
 
 // MARK: - Additional Initializers
@@ -384,49 +363,5 @@ extension Quaternion: CustomDebugStringConvertible {
     let c = String(reflecting: components.z)
     let d = String(reflecting: components.w)
     return "Quaternion<\(RealType.self)>(\(a), \(b), \(c), \(d))"
-  }
-}
-
-// MARK: - Operations for working with polar form
-extension Quaternion {
-
-  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(a*a + b*b + c*c + d*d)`).
-  ///
-  /// Note that it *is* possible for this property to overflow,
-  /// because `lengthSquared` is highly prone to overflow or underflow.
-  ///
-  /// For most use cases, you can use the cheaper `.magnitude`
-  /// property (which computes the ∞-norm) instead, which always produces
-  /// a representable result.
-  ///
-  /// Edge cases:
-  /// -
-  /// If a quaternion is not finite, its `.length` is `infinity`.
-  ///
-  /// See also:
-  /// -
-  /// - `.magnitude`
-  /// - `.lengthSquared`
-  @_transparent
-  public var length: RealType {
-    guard isFinite else { return .infinity }
-    return .sqrt(lengthSquared)
-  }
-
-  /// The squared length `(a*a + b*b + c*c + d*d)`.
-  ///
-  /// This property is more efficient to compute than `length`.
-  ///
-  /// This value is highly prone to overflow or underflow.
-  /// For many cases, `.magnitude` can be used instead, which is similarly
-  /// cheap to compute and always returns a representable value.
-  ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.magnitude`
-  @_transparent
-  public var lengthSquared: RealType {
-    (components * components).sum()
   }
 }

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -155,8 +155,8 @@ extension Quaternion {
 
   /// True if this value is normal.
   ///
-  /// A quaternion is normal if it is finite and *either* the real or *all* of the imaginary
-  /// components are normal. A floating-point number representing one of the components is normal
+  /// A quaternion is normal if it is finite and *any* of its real or imaginary components
+  /// are normal. A floating-point number representing one of the components is normal
   /// if its exponent allows a full-precision representation.
   ///
   /// See also:
@@ -167,9 +167,12 @@ extension Quaternion {
   /// - `.isPure`
   @_transparent
   public var isNormal: Bool {
-    let realIsNormal = components.x.isNormal
-    let imaginaryIsNormal = components.y.isNormal && components.z.isNormal && components.w.isNormal
-    return isFinite && (realIsNormal || imaginaryIsNormal)
+    return isFinite && (
+      components.x.isNormal ||
+      components.y.isNormal ||
+      components.z.isNormal ||
+      components.w.isNormal
+    )
   }
 
   /// True if this value is subnormal.

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -87,6 +87,8 @@ extension Quaternion {
   /// -
   /// - .one
   /// - .i
+  /// - .j
+  /// - .k
   /// - .infinity
   @_transparent
   public static var zero: Quaternion {
@@ -99,22 +101,54 @@ extension Quaternion {
   /// -
   /// - .zero
   /// - .i
+  /// - .j
+  /// - .k
   /// - .infinity
   @_transparent
   public static var one: Quaternion {
     Quaternion(from: SIMD4(0,0,0,1))
   }
 
-  /// The imaginary unit.
+  /// The quaternion with the imaginary unit **i** one, i.e. `0 + i + 0j + 0k`.
   ///
   /// See also:
   /// -
   /// - .zero
   /// - .one
+  /// - .j
+  /// - .k
   /// - .infinity
   @_transparent
   public static var i: Quaternion {
-    Quaternion(imaginary: SIMD3(repeating: 1))
+    Quaternion(imaginary: SIMD3(1,0,0))
+  }
+
+  /// The quaternion with the imaginary unit **j** one, i.e. `0 + 0i + j + 0k`.
+  ///
+  /// See also:
+  /// -
+  /// - .zero
+  /// - .one
+  /// - .i
+  /// - .k
+  /// - .infinity
+  @_transparent
+  public static var j: Quaternion {
+    Quaternion(imaginary: SIMD3(0,1,0))
+  }
+
+  /// The quaternion with the imaginary unit **k** one, i.e. `0 + 0i + 0j + k`.
+  ///
+  /// See also:
+  /// -
+  /// - .zero
+  /// - .one
+  /// - .i
+  /// - .j
+  /// - .infinity
+  @_transparent
+  public static var k: Quaternion {
+    Quaternion(imaginary: SIMD3(0,0,1))
   }
 
   /// The point at infinity.
@@ -124,6 +158,8 @@ extension Quaternion {
   /// - .zero
   /// - .one
   /// - .i
+  /// - .j
+  /// - .k
   @_transparent
   public static var infinity: Quaternion {
     Quaternion(.infinity)

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -236,20 +236,20 @@ extension Quaternion {
   ///
   /// Equivalent to `Quaternion(0, imaginary)`.
   @inlinable
-  public init(imaginary: (x: RealType, y: RealType, z: RealType)) {
-    self.init(imaginary: SIMD3(imaginary.x, imaginary.y, imaginary.z))
+  public init(imaginary x: RealType, _ y: RealType, _ z: RealType) {
+    self.init(imaginary: SIMD3(x, y, z))
   }
 
   /// The quaternion with specified real part and imaginary parts.
   @inlinable
   public init(_ real: RealType, _ imaginary: SIMD3<RealType>) {
-    self.init(from: SIMD4(imaginary.x, imaginary.y, imaginary.z, real))
+    self.init(from: SIMD4(imaginary, real))
   }
 
   /// The quaternion with specified real part and imaginary parts.
   @inlinable
-  public init(_ real: RealType, _ imaginary: (x: RealType, y: RealType, z: RealType)) {
-    self.init(real, SIMD3(imaginary.x, imaginary.y, imaginary.z))
+  public init(real: RealType, imaginary x: RealType, _ y: RealType, _ z: RealType) {
+    self.init(real, SIMD3(x, y, z))
   }
 
   /// The quaternion with specified real part and zero imaginary part.

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -132,7 +132,7 @@ extension Quaternion {
   /// The conjugate of this quaternion.
   @_transparent
   public var conjugate: Quaternion {
-    Quaternion(from: components.replacing(with: -components, where: [true, true, true, false]))
+    Quaternion(from: components * [-1, -1, -1, 1])
   }
 
   /// True if this value is finite.

--- a/Sources/QuaternionModule/README.md
+++ b/Sources/QuaternionModule/README.md
@@ -1,6 +1,7 @@
 # Quaternion
 
-This module provides a `Quaternion` type generic over an underlying `RealType`:
+This module provides a `Quaternion` type over an underlying `RealType`:
+
 ```swift
 1> import QuaternionModule
 2> let q = Quaternion(1, (1,1,1)) // q = 1 + i + j + k

--- a/Sources/QuaternionModule/README.md
+++ b/Sources/QuaternionModule/README.md
@@ -21,7 +21,7 @@ However, in practice there are good reasons to use something else instead:
 
 - The 2-norm requires special care to avoid spurious overflow/underflow, but the naive expressions for the 1-norm ("taxicab norm") or ∞-norm ("sup norm") are always correct.
 - Even when care is used, near the overflow boundary the 2-norm and the 1-norm are not representable.
-  As an example, consider `q = Quaternion(big, big, big, big)`, where `big` is `Double.greatestFiniteMagnitude`. The 1-norm and 2-norm of `q` both overflow (the 1-norm would be `4*big`, and the 2-norm would be `sqrt(4)*big`, neither of which are representable as `Double`), but the ∞-norm is always equal to either `real`, `i`, `j` or `k`, so it is guaranteed to be representable.
+  As an example, consider `q = Quaternion(big, (big, big, big))`, where `big` is `Double.greatestFiniteMagnitude`. The 1-norm and 2-norm of `q` both overflow (the 1-norm would be `4*big`, and the 2-norm would be `sqrt(4)*big`, neither of which are representable as `Double`), but the ∞-norm is always equal to either `real`, `i`, `j` or `k`, so it is guaranteed to be representable.
 Because of this, the ∞-norm is the obvious alternative; it gives the nicest API surface.
 - If we consider the magnitude of more exotic types, like operators, the 1-norm and ∞-norm are significantly easier to compute than the 2-norm (O(n) vs. "no closed form expression, but O(n^3) iterative methods"), so it is nice to establish a precedent of `.magnitude` binding one of these cheaper-to-compute norms.
 - The ∞-norm is heavily used in other computational libraries; for example, it is used by the `izamax` and `icamax` functions in BLAS.

--- a/Sources/QuaternionModule/README.md
+++ b/Sources/QuaternionModule/README.md
@@ -1,6 +1,6 @@
 # Quaternion
 
-This module provides a `Quaternion` type over an underlying `RealType`:
+This module provides a `Quaternion` type generic over an underlying `RealType`:
 
 ```swift
 1> import QuaternionModule

--- a/Sources/QuaternionModule/README.md
+++ b/Sources/QuaternionModule/README.md
@@ -1,0 +1,29 @@
+# Quaternion
+
+This module provides a `Quaternion` type generic over an underlying `RealType`:
+```swift
+1> import QuaternionModule
+2> let q = Quaternion(1, (1,1,1)) // q = 1 + i + j + k
+```
+
+The usual arithmetic operators are provided for Quaternions, many useful properties, plus conformances to the
+obvious usual protocols: `Equatable`, `Hashable`, `Codable` (if the underlying `RealType` is), and `AlgebraicField`
+(hence also `AdditiveArithmetic` and `SignedNumeric`).
+
+### Dependencies:
+- `RealModule`.
+
+### The magnitude property
+The `Numeric` protocol requires a `.magnitude` property, but (deliberately) does not fully specify the semantics.
+The most obvious choice for `Quaternion` would be to use the Euclidean norm (aka the "2-norm", given by `sqrt(real*real + i*i + k*k + j*j)`).
+However, in practice there are good reasons to use something else instead:
+
+- The 2-norm requires special care to avoid spurious overflow/underflow, but the naive expressions for the 1-norm ("taxicab norm") or ∞-norm ("sup norm") are always correct.
+- Even when care is used, near the overflow boundary the 2-norm and the 1-norm are not representable.
+  As an example, consider `q = Quaternion(big, big, big, big)`, where `big` is `Double.greatestFiniteMagnitude`. The 1-norm and 2-norm of `q` both overflow (the 1-norm would be `4*big`, and the 2-norm would be `sqrt(4)*big`, neither of which are representable as `Double`), but the ∞-norm is always equal to either `real`, `i`, `j` or `k`, so it is guaranteed to be representable.
+Because of this, the ∞-norm is the obvious alternative; it gives the nicest API surface.
+- If we consider the magnitude of more exotic types, like operators, the 1-norm and ∞-norm are significantly easier to compute than the 2-norm (O(n) vs. "no closed form expression, but O(n^3) iterative methods"), so it is nice to establish a precedent of `.magnitude` binding one of these cheaper-to-compute norms.
+- The ∞-norm is heavily used in other computational libraries; for example, it is used by the `izamax` and `icamax` functions in BLAS.
+
+The 2-norm still needs to be available, of course, because sometimes you need it.
+This functionality is accessed via the `.length` and `.lengthSquared` properties.

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -16,10 +16,50 @@ import RealModule
 
 final class ArithmeticTests: XCTestCase {
 
+  func testMultiplication<T: Real & ExpressibleByFloatLiteral & SIMDScalar>(_ type: T.Type) {
+    for value: T in [-3, -2, -1, +1, +2, +3] {
+      let q = Quaternion<T>(value, (value, value, value))
+      XCTAssertEqual(q * .one, q)
+      XCTAssertEqual(q * 1, q)
+      XCTAssertEqual(1 * q, q)
+    }
+  }
+
+  func testMultiplication() {
+    testMultiplication(Float32.self)
+    testMultiplication(Float64.self)
+  }
+
+  func testDivision<T: Real & ExpressibleByFloatLiteral & SIMDScalar>(_ type: T.Type) {
+    for value: T in [-3, -2, -1, +1, +2, +3] {
+      let q = Quaternion(value, (value, value, value))
+      XCTAssertEqual(q/q, .one)
+      XCTAssertEqual(0/q, .zero)
+
+      for s: Quaternion<T> in [-3, -2, -1, 0, +1, +2, +3] {
+        XCTAssertEqual(s/q, s * q.reciprocal!)
+      }
+
+      for s: T in [-3, -2, -1, +1, +2, +3] {
+        XCTAssertEqual(q.divided(by: s), q.multiplied(by: 1.0/s))
+      }
+    }
+  }
+
+  func testDivision() {
+    testDivision(Float32.self)
+    testDivision(Float64.self)
+  }
+
+  func testDivisionByZero<T: Real & SIMDScalar>(_ type: T.Type) {
+    XCTAssertFalse((Quaternion<T>(0, (0, 0, 0)) / Quaternion<T>(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion<T>(1, (1, 1, 1)) / Quaternion<T>(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion<T>.infinity / Quaternion<T>(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion<T>.i / Quaternion<T>(0, (0, 0, 0))).isFinite)
+  }
+
   func testDivisionByZero() {
-    XCTAssertFalse((Quaternion(0, (0, 0, 0)) / Quaternion(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion(1, (1, 1, 1)) / Quaternion(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion.infinity / Quaternion(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion.i / Quaternion(0, (0, 0, 0))).isFinite)
+    testDivisionByZero(Float32.self)
+    testDivisionByZero(Float64.self)
   }
 }

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -18,7 +18,7 @@ final class ArithmeticTests: XCTestCase {
 
   func testMultiplication<T: Real & SIMDScalar>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
-      let q = Quaternion<T>(value, (value, value, value))
+      let q = Quaternion<T>(real: value, imaginary: value, value, value)
       XCTAssertEqual(q * .one, q)
       XCTAssertEqual(q * 1, q)
       XCTAssertEqual(1 * q, q)
@@ -32,7 +32,7 @@ final class ArithmeticTests: XCTestCase {
 
   func testDivision<T: Real & SIMDScalar>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
-      let q = Quaternion<T>(value, (value, value, value))
+      let q = Quaternion<T>(real: value, imaginary: value, value, value)
       XCTAssertEqual(q/q, .one)
       XCTAssertEqual(0/q, .zero)
 
@@ -52,10 +52,12 @@ final class ArithmeticTests: XCTestCase {
   }
 
   func testDivisionByZero<T: Real & SIMDScalar>(_ type: T.Type) {
-    XCTAssertFalse((Quaternion<T>(0, (0, 0, 0)) / Quaternion<T>(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion<T>(1, (1, 1, 1)) / Quaternion<T>(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion<T>.infinity / Quaternion<T>(0, (0, 0, 0))).isFinite)
-    XCTAssertFalse((Quaternion<T>.i / Quaternion<T>(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion<T>(real: 0, imaginary: 0, 0, 0) / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
+    XCTAssertFalse((Quaternion<T>(real: 1, imaginary: 1, 1, 1) / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
+    XCTAssertFalse((Quaternion<T>.infinity / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
+    XCTAssertFalse((Quaternion<T>.i / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
+    XCTAssertFalse((Quaternion<T>.j / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
+    XCTAssertFalse((Quaternion<T>.k / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
   }
 
   func testDivisionByZero() {

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -1,0 +1,25 @@
+//===--- ArithmeticTests.swift --------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import RealModule
+
+@testable import QuaternionModule
+
+final class ArithmeticTests: XCTestCase {
+
+  func testDivisionByZero() {
+    XCTAssertFalse((Quaternion(0, (0, 0, 0)) / Quaternion(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion(1, (1, 1, 1)) / Quaternion(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion.infinity / Quaternion(0, (0, 0, 0))).isFinite)
+    XCTAssertFalse((Quaternion.i / Quaternion(0, (0, 0, 0))).isFinite)
+  }
+}

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -16,7 +16,7 @@ import RealModule
 
 final class ArithmeticTests: XCTestCase {
 
-  func testMultiplication<T: Real & ExpressibleByFloatLiteral & SIMDScalar>(_ type: T.Type) {
+  func testMultiplication<T: Real & SIMDScalar>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
       let q = Quaternion<T>(value, (value, value, value))
       XCTAssertEqual(q * .one, q)
@@ -30,18 +30,18 @@ final class ArithmeticTests: XCTestCase {
     testMultiplication(Float64.self)
   }
 
-  func testDivision<T: Real & ExpressibleByFloatLiteral & SIMDScalar>(_ type: T.Type) {
+  func testDivision<T: Real & SIMDScalar>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
       let q = Quaternion(value, (value, value, value))
       XCTAssertEqual(q/q, .one)
       XCTAssertEqual(0/q, .zero)
 
-      for s: Quaternion<T> in [-3, -2, -1, 0, +1, +2, +3] {
-        XCTAssertEqual(s/q, s * q.reciprocal!)
+      for q2: Quaternion<T> in [-3, -2, -1, 0, +1, +2, +3] {
+        XCTAssertEqual(q2/q, q2 * q.reciprocal!)
       }
 
-      for s: T in [-3, -2, -1, +1, +2, +3] {
-        XCTAssertEqual(q.divided(by: s), q.multiplied(by: 1.0/s))
+      for q2: T in [-3, -2, -1, +1, +2, +3] {
+        XCTAssertEqual(q.divided(by: q2), q.multiplied(by: 1.0/q2))
       }
     }
   }

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -32,7 +32,7 @@ final class ArithmeticTests: XCTestCase {
 
   func testDivision<T: Real & SIMDScalar>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
-      let q = Quaternion(value, (value, value, value))
+      let q = Quaternion<T>(value, (value, value, value))
       XCTAssertEqual(q/q, .one)
       XCTAssertEqual(0/q, .zero)
 
@@ -41,7 +41,7 @@ final class ArithmeticTests: XCTestCase {
       }
 
       for q2: T in [-3, -2, -1, +1, +2, +3] {
-        XCTAssertEqual(q.divided(by: q2), q.multiplied(by: 1.0/q2))
+        XCTAssertEqual(q.divided(by: q2), q.multiplied(by: 1/q2))
       }
     }
   }

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -1,0 +1,20 @@
+//===--- PropertyTests.swift ----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import QuaternionModule
+
+final class PropertyTests: XCTestCase {
+
+    func testComponentInitializer() {
+        let _ = Quaternion(3, (1, 2, 3))
+    }
+}

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -10,11 +10,128 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import RealModule
+
 @testable import QuaternionModule
 
 final class PropertyTests: XCTestCase {
 
-    func testComponentInitializer() {
-        let _ = Quaternion(3, (1, 2, 3))
+  func testProperties<T: Real & SIMDScalar>(_ type: T.Type) {
+    // The real and imaginary parts of a non-finite value should be nan.
+    XCTAssertTrue(Quaternion<T>.infinity.real.isNaN)
+    XCTAssertTrue(Quaternion<T>.infinity.imaginary.x.isNaN)
+    XCTAssertTrue(Quaternion<T>.infinity.imaginary.y.isNaN)
+    XCTAssertTrue(Quaternion<T>.infinity.imaginary.z.isNaN)
+    XCTAssertTrue(Quaternion<T>(.infinity, (.nan, .nan, .nan)).real.isNaN)
+    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.x.isNaN)
+    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.y.isNaN)
+    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.z.isNaN)
+    // The length of a non-finite value should be infinity.
+    XCTAssertEqual(Quaternion<T>.infinity.length, .infinity)
+    XCTAssertEqual(Quaternion<T>(.infinity, (.nan, .nan, .nan)).length, .infinity)
+    XCTAssertEqual(Quaternion<T>(.nan, (0, 0, 0)).length, .infinity)
+    // The length of a zero value should be zero.
+    XCTAssertEqual(Quaternion<T>.zero.length, .zero)
+    XCTAssertEqual(Quaternion<T>(.zero, -.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(-.zero,-.zero).length, .zero)
+  }
+
+  func testProperties() {
+    testProperties(Float32.self)
+    testProperties(Float64.self)
+  }
+
+  func testEquatableHashable<T: Real & SIMDScalar>(_ type: T.Type) {
+    // Validate that all zeros compare and hash equal, and all non-finites
+    // do too.
+    let zeros = [
+      Quaternion<T>( .zero, ( .zero,  .zero,  .zero)),
+      Quaternion<T>( .zero, (-.zero,  .zero,  .zero)),
+      Quaternion<T>( .zero, ( .zero, -.zero,  .zero)),
+      Quaternion<T>( .zero, ( .zero,  .zero, -.zero)),
+      Quaternion<T>( .zero, (-.zero, -.zero,  .zero)),
+      Quaternion<T>( .zero, (-.zero,  .zero, -.zero)),
+      Quaternion<T>( .zero, ( .zero, -.zero, -.zero)),
+      Quaternion<T>( .zero, (-.zero, -.zero, -.zero)),
+
+      Quaternion<T>(-.zero, ( .zero,  .zero,  .zero)),
+      Quaternion<T>(-.zero, (-.zero,  .zero,  .zero)),
+      Quaternion<T>(-.zero, ( .zero, -.zero,  .zero)),
+      Quaternion<T>(-.zero, ( .zero,  .zero, -.zero)),
+      Quaternion<T>(-.zero, (-.zero, -.zero,  .zero)),
+      Quaternion<T>(-.zero, (-.zero,  .zero, -.zero)),
+      Quaternion<T>(-.zero, ( .zero, -.zero, -.zero)),
+      Quaternion<T>(-.zero, (-.zero, -.zero, -.zero))
+    ]
+    for z in zeros[1...] {
+      XCTAssertEqual(zeros[0], z)
+      XCTAssertEqual(zeros[0].hashValue, z.hashValue)
     }
+    let infs = [
+      Quaternion<T>( .nan,      (.nan, .nan, .nan)),
+      Quaternion<T>(-.infinity, (.nan, .nan, .nan)),
+      Quaternion<T>(-.ulpOfOne, (.nan, .nan, .nan)),
+      Quaternion<T>( .zero,     (.nan, .nan, .nan)),
+      Quaternion<T>( .pi,       (.nan, .nan, .nan)),
+      Quaternion<T>( .infinity, (.nan, .nan, .nan)),
+      Quaternion<T>( .nan,      (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>(-.infinity, (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>(-.ulpOfOne, (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>( .zero,     (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>( .pi,       (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>( .infinity, (-.infinity, -.infinity, -.infinity)),
+      Quaternion<T>( .nan,      (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
+      Quaternion<T>(-.infinity, (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
+      Quaternion<T>( .infinity, (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
+      Quaternion<T>( .nan,      (.zero, .zero, .zero)),
+      Quaternion<T>(-.infinity, (.zero, .zero, .zero)),
+      Quaternion<T>( .infinity, (.zero, .zero, .zero)),
+      Quaternion<T>( .nan,      (.pi, .pi, .pi)),
+      Quaternion<T>(-.infinity, (.pi, .pi, .pi)),
+      Quaternion<T>( .infinity, (.pi, .pi, .pi)),
+      Quaternion<T>( .nan,      (.infinity, .infinity, .infinity)),
+      Quaternion<T>(-.infinity, (.infinity, .infinity, .infinity)),
+      Quaternion<T>(-.ulpOfOne, (.infinity, .infinity, .infinity)),
+      Quaternion<T>( .zero,     (.infinity, .infinity, .infinity)),
+      Quaternion<T>( .pi,       (.infinity, .infinity, .infinity)),
+      Quaternion<T>( .infinity, (.infinity, .infinity, .infinity)),
+    ]
+    for i in infs[1...] {
+      XCTAssertEqual(infs[0], i)
+      XCTAssertEqual(infs[0].hashValue, i.hashValue)
+    }
+  }
+
+  func testEquatableHashable() {
+    testEquatableHashable(Float32.self)
+    testEquatableHashable(Float64.self)
+  }
+
+  func testCodable<T: Real & SIMDScalar>(_ type: T.Type) throws {
+    let encoder = JSONEncoder()
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(
+      positiveInfinity: "inf",
+      negativeInfinity: "-inf",
+      nan: "nan"
+    )
+
+    let decoder = JSONDecoder()
+    decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+      positiveInfinity: "inf",
+      negativeInfinity: "-inf",
+      nan: "nan"
+    )
+
+    for expected: Quaternion<T> in [.zero, .one, .i, .infinity] {
+      let data = try encoder.encode(expected)
+//      print("*** \(String(decoding: data, as: Unicode.UTF8.self)) ***")
+      let actual = try decoder.decode(Quaternion<T>.self, from: data)
+      XCTAssertEqual(actual, expected)
+    }
+  }
+
+  func testCodable() throws {
+    try testCodable(Float32.self)
+    try testCodable(Float64.self)
+  }
 }

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -124,7 +124,6 @@ final class PropertyTests: XCTestCase {
 
     for expected: Quaternion<T> in [.zero, .one, .i, .infinity] {
       let data = try encoder.encode(expected)
-//      print("*** \(String(decoding: data, as: Unicode.UTF8.self)) ***")
       let actual = try decoder.decode(Quaternion<T>.self, from: data)
       XCTAssertEqual(actual, expected)
     }

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -22,18 +22,18 @@ final class PropertyTests: XCTestCase {
     XCTAssertTrue(Quaternion<T>.infinity.imaginary.x.isNaN)
     XCTAssertTrue(Quaternion<T>.infinity.imaginary.y.isNaN)
     XCTAssertTrue(Quaternion<T>.infinity.imaginary.z.isNaN)
-    XCTAssertTrue(Quaternion<T>(.infinity, (.nan, .nan, .nan)).real.isNaN)
-    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.x.isNaN)
-    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.y.isNaN)
-    XCTAssertTrue(Quaternion<T>(.nan, (0, 0, 0)).imaginary.z.isNaN)
+    XCTAssertTrue(Quaternion<T>(real: .infinity, imaginary: .nan, .nan, .nan).real.isNaN)
+    XCTAssertTrue(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).imaginary.x.isNaN)
+    XCTAssertTrue(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).imaginary.y.isNaN)
+    XCTAssertTrue(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).imaginary.z.isNaN)
     // The length of a non-finite value should be infinity.
     XCTAssertEqual(Quaternion<T>.infinity.length, .infinity)
-    XCTAssertEqual(Quaternion<T>(.infinity, (.nan, .nan, .nan)).length, .infinity)
-    XCTAssertEqual(Quaternion<T>(.nan, (0, 0, 0)).length, .infinity)
+    XCTAssertEqual(Quaternion<T>(real: .infinity, imaginary: .nan, .nan, .nan).length, .infinity)
+    XCTAssertEqual(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).length, .infinity)
     // The length of a zero value should be zero.
     XCTAssertEqual(Quaternion<T>.zero.length, .zero)
     XCTAssertEqual(Quaternion<T>(.zero, -.zero).length, .zero)
-    XCTAssertEqual(Quaternion<T>(-.zero,-.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(-.zero, -.zero).length, .zero)
   }
 
   func testProperties() {
@@ -45,56 +45,56 @@ final class PropertyTests: XCTestCase {
     // Validate that all zeros compare and hash equal, and all non-finites
     // do too.
     let zeros = [
-      Quaternion<T>( .zero, ( .zero,  .zero,  .zero)),
-      Quaternion<T>( .zero, (-.zero,  .zero,  .zero)),
-      Quaternion<T>( .zero, ( .zero, -.zero,  .zero)),
-      Quaternion<T>( .zero, ( .zero,  .zero, -.zero)),
-      Quaternion<T>( .zero, (-.zero, -.zero,  .zero)),
-      Quaternion<T>( .zero, (-.zero,  .zero, -.zero)),
-      Quaternion<T>( .zero, ( .zero, -.zero, -.zero)),
-      Quaternion<T>( .zero, (-.zero, -.zero, -.zero)),
+        Quaternion<T>(real:  .zero, imaginary:  .zero,  .zero,  .zero),
+        Quaternion<T>(real:  .zero, imaginary: -.zero,  .zero,  .zero),
+        Quaternion<T>(real:  .zero, imaginary:  .zero, -.zero,  .zero),
+        Quaternion<T>(real:  .zero, imaginary:  .zero,  .zero, -.zero),
+        Quaternion<T>(real:  .zero, imaginary: -.zero, -.zero,  .zero),
+        Quaternion<T>(real:  .zero, imaginary: -.zero,  .zero, -.zero),
+        Quaternion<T>(real:  .zero, imaginary:  .zero, -.zero, -.zero),
+        Quaternion<T>(real:  .zero, imaginary: -.zero, -.zero, -.zero),
 
-      Quaternion<T>(-.zero, ( .zero,  .zero,  .zero)),
-      Quaternion<T>(-.zero, (-.zero,  .zero,  .zero)),
-      Quaternion<T>(-.zero, ( .zero, -.zero,  .zero)),
-      Quaternion<T>(-.zero, ( .zero,  .zero, -.zero)),
-      Quaternion<T>(-.zero, (-.zero, -.zero,  .zero)),
-      Quaternion<T>(-.zero, (-.zero,  .zero, -.zero)),
-      Quaternion<T>(-.zero, ( .zero, -.zero, -.zero)),
-      Quaternion<T>(-.zero, (-.zero, -.zero, -.zero))
+        Quaternion<T>(real: -.zero, imaginary:  .zero,  .zero,  .zero),
+        Quaternion<T>(real: -.zero, imaginary: -.zero,  .zero,  .zero),
+        Quaternion<T>(real: -.zero, imaginary:  .zero, -.zero,  .zero),
+        Quaternion<T>(real: -.zero, imaginary:  .zero,  .zero, -.zero),
+        Quaternion<T>(real: -.zero, imaginary: -.zero, -.zero,  .zero),
+        Quaternion<T>(real: -.zero, imaginary: -.zero,  .zero, -.zero),
+        Quaternion<T>(real: -.zero, imaginary:  .zero, -.zero, -.zero),
+        Quaternion<T>(real: -.zero, imaginary: -.zero, -.zero, -.zero)
     ]
     for z in zeros[1...] {
       XCTAssertEqual(zeros[0], z)
       XCTAssertEqual(zeros[0].hashValue, z.hashValue)
     }
     let infs = [
-      Quaternion<T>( .nan,      (.nan, .nan, .nan)),
-      Quaternion<T>(-.infinity, (.nan, .nan, .nan)),
-      Quaternion<T>(-.ulpOfOne, (.nan, .nan, .nan)),
-      Quaternion<T>( .zero,     (.nan, .nan, .nan)),
-      Quaternion<T>( .pi,       (.nan, .nan, .nan)),
-      Quaternion<T>( .infinity, (.nan, .nan, .nan)),
-      Quaternion<T>( .nan,      (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>(-.infinity, (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>(-.ulpOfOne, (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>( .zero,     (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>( .pi,       (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>( .infinity, (-.infinity, -.infinity, -.infinity)),
-      Quaternion<T>( .nan,      (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
-      Quaternion<T>(-.infinity, (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
-      Quaternion<T>( .infinity, (-.ulpOfOne, -.ulpOfOne, -.ulpOfOne)),
-      Quaternion<T>( .nan,      (.zero, .zero, .zero)),
-      Quaternion<T>(-.infinity, (.zero, .zero, .zero)),
-      Quaternion<T>( .infinity, (.zero, .zero, .zero)),
-      Quaternion<T>( .nan,      (.pi, .pi, .pi)),
-      Quaternion<T>(-.infinity, (.pi, .pi, .pi)),
-      Quaternion<T>( .infinity, (.pi, .pi, .pi)),
-      Quaternion<T>( .nan,      (.infinity, .infinity, .infinity)),
-      Quaternion<T>(-.infinity, (.infinity, .infinity, .infinity)),
-      Quaternion<T>(-.ulpOfOne, (.infinity, .infinity, .infinity)),
-      Quaternion<T>( .zero,     (.infinity, .infinity, .infinity)),
-      Quaternion<T>( .pi,       (.infinity, .infinity, .infinity)),
-      Quaternion<T>( .infinity, (.infinity, .infinity, .infinity)),
+      Quaternion<T>(real:  .nan,      imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real: -.infinity, imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real: -.ulpOfOne, imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real:  .zero,     imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real:  .pi,       imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real:  .infinity, imaginary: .nan, .nan, .nan),
+      Quaternion<T>(real:  .nan,      imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real: -.infinity, imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real: -.ulpOfOne, imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real:  .zero,     imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real:  .pi,       imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real:  .infinity, imaginary: -.infinity, -.infinity, -.infinity),
+      Quaternion<T>(real:  .nan,      imaginary: -.ulpOfOne, -.ulpOfOne, -.ulpOfOne),
+      Quaternion<T>(real: -.infinity, imaginary: -.ulpOfOne, -.ulpOfOne, -.ulpOfOne),
+      Quaternion<T>(real:  .infinity, imaginary: -.ulpOfOne, -.ulpOfOne, -.ulpOfOne),
+      Quaternion<T>(real:  .nan,      imaginary: .zero, .zero, .zero),
+      Quaternion<T>(real: -.infinity, imaginary: .zero, .zero, .zero),
+      Quaternion<T>(real:  .infinity, imaginary: .zero, .zero, .zero),
+      Quaternion<T>(real:  .nan,      imaginary: .pi, .pi, .pi),
+      Quaternion<T>(real: -.infinity, imaginary: .pi, .pi, .pi),
+      Quaternion<T>(real:  .infinity, imaginary: .pi, .pi, .pi),
+      Quaternion<T>(real:  .nan,      imaginary: .infinity, .infinity, .infinity),
+      Quaternion<T>(real: -.infinity, imaginary: .infinity, .infinity, .infinity),
+      Quaternion<T>(real: -.ulpOfOne, imaginary: .infinity, .infinity, .infinity),
+      Quaternion<T>(real:  .zero,     imaginary: .infinity, .infinity, .infinity),
+      Quaternion<T>(real:  .pi,       imaginary: .infinity, .infinity, .infinity),
+      Quaternion<T>(real:  .infinity, imaginary: .infinity, .infinity, .infinity),
     ]
     for i in infs[1...] {
       XCTAssertEqual(infs[0], i)


### PR DESCRIPTION
This PR adds `Quaternion` as part of a new module called `QuaternionModule`.

- Issue: #35

## API Notes

A `Quaternion` contains 4 numeric values conforming to `Real & SIMDScalar`. The numeric type is simply called `RealType` for the remaining notes and considerations. Implementation-wise, `Quaternion` wraps the SIMD4 type from the Standard Library, though it does not expose the SIMD storage publicly – both the initializer and the property (called `components`) are **only** visible to module. It stores the 4 numeric values using a common convention of most graphics libraries in the form of: `xi + yj + zk + r`, i.e. `SIMD4(x, y, z, r)`. 

Publicy, the `Quaternion` is represented by a `real` and an `imaginary` part, where `real` is of `RealType` and `imaginary` is of `SIMD3<RealType>` type. To create a `Quaternion` with matching properties, the following initializers are publicly available:

```swift
init(_ real: RealType, _ imaginary: SIMD3<RealType>)
init(real: RealType, imaginary x: RealType, _ y: RealType, _ z: RealType)
```

Additionally, there are convenience initializer available in the form of:

```swift
init(_ real: RealType) // Equivalent to `Quaternion(real, SIMD3(repeating: 0))`.
init(imaginary: SIMD3<RealType>) // Equivalent to `Quaternion(0, imaginary)`.
init(imaginary x: RealType, _ y: RealType, _ z: RealType) // Equivalent to `Quaternion(real: 0, imaginary: x, y, z)`.
```

Furthermore, `Quaternion` conforms to `ExpressiblyByIntegerLiteral` and `Numeric`,
"therefore" the following initializers are available as well:

```swift
init<Other>(_ real: Other) where Other : BinaryInteger
init?<Other>(exactly real: Other) where Other : BinaryInteger
init(integerLiteral value: Int)
```

And lastly, to allow conversion (and arithmetics) between quaternions of different
floating-point precision, the module exposes the following initializers:

```swift
extension Quaternion where RealType : BinaryFloatingPoint {
  init<Other>(_ other: Quaternion<Other>) where Other : Real & BinaryFloatingPoint & SIMDScalar
  init?<Other>(exactly other: Quaternion<Other>) where Other : Real & BinaryFloatingPoint & SIMDScalar
}
```

The module provides the following static properties on `Quaternion`:

```swift
/// The additive identity, with real and *all* imaginary parts zero.
static var zero: Quaternion { get }
/// The multiplicative identity, with real part one and *all* imaginary parts zero.
static var one: Quaternion { get }
/// The quaternion with the imaginary unit **i** one, i.e. `0 + i + 0j + 0k`.
static var i: Quaternion { get }
/// The quaternion with the imaginary unit **j** one, i.e. `0 + 0i + j + 0k`.
static var j: Quaternion { get }
/// The quaternion with the imaginary unit **k** one, i.e. `0 + 0i + 0j + k`.
static var k: Quaternion { get }
/// The point at infinity.
static var infinity: Quaternion { get }
```

And the following properties:

```swift
/// The conjugate of this quaternion.
var conjugate: Quaternion { get }
/// True if this value is finite.
var isFinite: Bool { get }
/// True if this value is normal.
var isNormal: Bool { get }
/// True if this value is subnormal.
var isSubnormal: Bool { get }
/// True if this value is zero.
var isZero: Bool { get }
/// True if this value is only defined by the imaginary parts.
var isPure: Bool { get }
```

`Quaternion` conforms to `Hashable` (and therefore `Equatable`), `Decodable`,
`Encodable`, `CustomStringConvertible` and `CustomDebugStringConvertible`. The
implementation is rather simple. You can find the details in the `Quaternion.swift` file.


### Arithmetics

A `Quaternion` conforms to `AdditiveArithmetic`. This yields the following arithmetic functions:

```swift
static func + (lhs: Quaternion, rhs: Quaternion) -> Quaternion
static func - (lhs: Quaternion, rhs: Quaternion) -> Quaternion
static func += (lhs: inout Quaternion, rhs: Quaternion)
static func -= (lhs: inout Quaternion, rhs: Quaternion)
```

As well as it conforms to `AlgebraicField` and therefore provides the following arithmetic functions:

```swift
static func * (lhs: Quaternion, rhs: Quaternion) -> Quaternion
static func / (lhs: Quaternion, rhs: Quaternion) -> Quaternion
static func *= (lhs: inout Quaternion, rhs: Quaternion)
static func /= (lhs: inout Quaternion, rhs: Quaternion)
var normalized: Quaternion? { get }
var reciprocal: Quaternion? { get }
```

> Note it does not provide heterogeneous Quaternion/Scalar arithmetic.
> You can find the reason/details in the considerations below.

### Norms

```swift
/// The ∞-norm (`max(abs(a), abs(b), abs(c), abs(d))`).
var magnitude: RealType { get }
/// The Euclidean norm (a.k.a. 2-norm, `sqrt(a*a + b*b + c*c + d*d)`).
var length: RealType { get }
/// The squared length `(a*a + b*b + c*c + d*d)`.
var lengthSquared: RealType { get }
```

While quaternions are often used as an abstraction for representing rotations this PR adds only the most basic type definition and does not define rotation (other than the polar form) or a vector type.
Furthermore, it does not provide a distinct unit quaternion although it provides a normalized variant via the `normalized` property. I think it is reasonable to have a distinct `UnitQuaternion` type that guarantees the underlying quaternion has unity `length`, but I think it should be as-well-as, rather than instead-of.

## Considerations

1. ~~The module provides an initializer to express the imaginary parts of a
quaternion as a tuple of 3 `RealType` values. This somehow "blocks" an initializer
being implemented that simply takes 4 values (e.g. `Quaternion(1,2,3,4)`) but
rather requires the imaginary parts in a additional parentheses (i.e.
`Quaternion(1, (2,3,4))`). The later one was implemented, as the order of the values
within the quaternion (real part first) is immediately visible and it aligns
nicely with the convenience initializer that takes imaginary values only as a tuple
(i.e. `Quaternion(imaginary: (2,3,4))`) but I have no strong opinion on it and
would love to get your feedback.~~ This has since been changed to: `init(real: RealType, imaginary x: RealType, _ y: RealType, _z: RealType)`
2. The `Quaternion` wraps the `SIMD4` type, however its storage is not exposed
publicly (nor is the initializer) as all of the necessary operations around
quaternions should (later) be available on the `Quaternion`, or via its
`real` and `imaginary` properties. This may yield performance issues for applications
where the entire storage is required. However it guarantees that all values have
fixup the semantics for non-finite values (much like `x/y` and `real/imaginary`
for `Complex` types).
3. The expressions `q * 1`, where `q` is a quaternion, will be interpreted by the
compiler as `q * Quaternion(1, (0,0,0))` due to the `ExpressibleByIntegerLiteral`
conformance and the implementation details of it. This aligns nicely with `q * .one`,
as the multiplicative identity of a quaternion (or `one`) is defined as
`Quaternion(1, (0,0,0))`. However, this adds ambiguity when viewed as vector
space structure, where `q * 1` should probably yield `q * Quaternion(1, (1,1,1))`.
This is the main reason why there is no heterogenous arithmetic available, much
like it is not available on the `Complex` type (Issue #12). I think, should it
ever "be fixed", it should be implemented on both types at the same time and equally.
4. ~~`Quaternion` defines `static var i: Quaternion` to return a pure quaternion with
all imaginary components at 1, i.e. `Quaternion(0, (1,1,1))`. This may be misleading
tough, as a quaternion is commonly written in the form of `a + bi + cj + dk` and could imply
that only the second (b**i**) part is 1. However, naming the static property
`imaginary` (to make it clearer that **all** imaginary components are of interest)
makes it so that there is a static property `static var imaginary: Quaternion` and a
non-static property `var imaginary: SIMD3<RealType>` available on quaternion, which
is also misleading. One solution to this could be to add `static var j: Quaternion`
and `static var k: Quaternion`. So to get a new quaternion with only the imaginary
components of another quaternion one could simply write `q * (.i + .j + .k)`.~~ There are now three distinct static properties available, named: `i`, `j` and `k`
5. Right now, the `Quaternion` does not provide a polar representation,
tough it should become part of this PR. Main reason: I would like to get your
opinion on it. Right now, I think the best way to define a polar form is via
an `angle` of `RealType` around an `axis` of `SIMD3<RealType` – much like it is defined
for [`simd_quatf`][simd_quatf] and [`simd_quatd`][simd_quatd].
However, to match the `Complex` type, it should probably be `axis` first and `angle` last.
This would add the following API to `Quaternion`:

```swift
init(axis: SIMD3<RealType>, phase: RealType)
var axis: SIMD3<RealType> { get }
var angle: RealType { get }
var polar: (axis: SIMD3<RealType>, angle: RealType) {
  (axis, angle)
}
```

## Missing

- [ ] Polar Form
- [ ] Additional Tests around arithmetics
- [ ] Additional Documentation

[simd_quatf]: https://developer.apple.com/documentation/simd/simd_quatf/2914611-init
[simd_quatd]:https://developer.apple.com/documentation/simd/simd_quatd/2914986-init