### PR TITLE
[Sketch] BigInt

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,18 +15,22 @@ import PackageDescription
 let package = Package(
   name: "swift-numerics",
   products: [
+    .library(name: "BigIntModule", targets: ["BigIntModule"]),
     .library(name: "ComplexModule", targets: ["ComplexModule"]),
     .library(name: "Numerics", targets: ["Numerics"]),
     .library(name: "RealModule", targets: ["RealModule"]),
   ],
   dependencies: [
+    .package(url: "https://github.com/attaswift/BigInt.git", from: "3.0.0")
   ],
   targets: [
+    .target(name: "BigIntModule", dependencies: []),
     .target(name: "ComplexModule", dependencies: ["RealModule"]),
     .target(name: "Numerics", dependencies: ["ComplexModule", "RealModule"]),
     .target(name: "_NumericsShims", dependencies: []),
     .target(name: "RealModule", dependencies: ["_NumericsShims"]),
     
+    .testTarget(name: "BigIntTests", dependencies: ["BigIntModule", "BigInt"]),
     .testTarget(name: "ComplexTests", dependencies: ["ComplexModule", "_NumericsShims"]),
     .testTarget(name: "RealTests", dependencies: ["RealModule"]),
   ]

--- a/Sources/BigIntModule/BigInt.Words.swift
+++ b/Sources/BigIntModule/BigInt.Words.swift
@@ -1,0 +1,76 @@
+extension BigInt {
+  /// The words of an arbitrarily large signed integer.
+  ///
+  /// For a negative value, words are of the two’s complement representation.
+  @frozen
+  public struct Words {
+    /// The arbitrarily large signed integer.
+    @usableFromInline
+    internal var _value: BigInt
+
+    /// Creates a `BigInt.Words` from the given arbitrarily large signed
+    /// integer.
+    ///
+    /// - Parameter value: The arbitrarily large signed integer.
+    @inlinable
+    public init(_ value: BigInt) {
+      _value = value
+    }
+  }
+}
+
+extension BigInt.Words: RandomAccessCollection {
+  @inlinable
+  public var count: Int {
+    if _value._combination == 0 { return 1 }
+    let temporary = _value._exponent + _value._significand.count
+    let lastIndex = _value._significand.count &- 1
+    let highWord = _value._significand[lastIndex]
+    guard Int(bitPattern: highWord) < 0 else {
+      return temporary
+    }
+    // If the leading bit is set, then--
+    //
+    // For a positive value:
+    // We need to add at least one leading zero bit (and therefore one
+    // additional word) for a signed representation.
+    if _value._combination > 0 { return temporary + 1 }
+    // For a negative value:
+    // The two's complement of a magnitude has the same bit width as that of
+    // the magnitude itself if and only if the magnitude is a power of two.
+    // Otherwise, we need one additional bit (and therefore one additional
+    // word) to fit the two's complement.
+    //
+    // (Note that `(x & (x &- 1)) == 0` is a method of determining if `x` is
+    // a power of two.)
+    return lastIndex == 0 && (highWord & (highWord &- 1)) == 0
+      ? temporary
+      : temporary + 1
+  }
+  
+  @inlinable
+  public var startIndex: Int { 0 }
+  
+  @inlinable
+  public var endIndex: Int { count }
+  
+  @inlinable
+  public func index(before i: Int) -> Int { i - 1 }
+  
+  @inlinable
+  public func index(after i: Int) -> Int { i + 1 }
+  
+  @inlinable
+  public subscript(position: Int) -> UInt {
+    precondition(position >= 0, "Index out of bounds")
+    guard position >= _value._exponent else { return 0 }
+    let idx = position &- _value._exponent
+    guard idx < _value._significand.count else {
+      return _value._combination < 0 ? UInt.max : 0
+    }
+    let word = _value._significand[idx]
+    return _value._combination < 0
+      ? idx == 0 ? ~word &+ 1 : ~word
+      : word
+  }
+}

--- a/Sources/BigIntModule/BigInt._Significand.swift
+++ b/Sources/BigIntModule/BigInt._Significand.swift
@@ -1,0 +1,663 @@
+extension BigInt {
+  /// The significand of a `BigInt` value, a nonempty collection of the
+  /// significant digits of that value's magnitude stored in words of type
+  /// `UInt`.
+  ///
+  /// The first element of the collection is the lowest word.
+  @frozen
+  @usableFromInline
+  internal struct _Significand {
+    /// The low word of this significand.
+    @usableFromInline
+    internal var _low: UInt
+    
+    /// The rest of the words of this significand, from second lowest to
+    /// highest.
+    @usableFromInline
+    internal var _rest: [UInt]
+    
+    /// Creates a new significand with a single low word equal to zero.
+    @inlinable
+    internal init() {
+      _low = 0
+      _rest = []
+    }
+
+    /// Creates a new significand with the given words.
+    @inlinable
+    internal init(_ low: UInt, _ rest: [UInt] = []) {
+      _low = low
+      _rest = rest
+    }
+  }
+}
+
+extension BigInt._Significand: RandomAccessCollection, MutableCollection {
+  @inlinable
+  internal var count: Int { _rest.count + 1 }
+  
+  @inlinable
+  internal var startIndex: Int { 0 }
+  
+  @inlinable
+  internal var endIndex: Int { count }
+  
+  @inlinable
+  internal func index(before i: Int) -> Int { i - 1 }
+  
+  @inlinable
+  internal func index(after i: Int) -> Int { i + 1 }
+  
+  @inlinable
+  internal subscript(position: Int) -> UInt {
+    _read {
+      if position == 0 {
+        yield _low
+      } else {
+        yield _rest[position - 1]
+      }
+    }
+    _modify {
+      if position == 0 {
+        yield &_low
+      } else {
+        yield &_rest[position - 1]
+      }
+    }
+  }
+}
+
+/// `BigInt._Coefficient` can never be empty, so it cannot conform to
+/// `RangeReplaceableCollection`; however, we will implement some of its
+/// requirements here.
+///
+/// Documentation is transposed from the corresponding methods on
+/// `RangeReplaceableCollection` in the standard library, with changes noted in
+/// **bold**.
+extension BigInt._Significand {
+  /// Replaces the specified subrange of elements with the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the collection and inserting the new elements at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.startIndex`. Calling
+  /// the `insert(contentsOf:at:)` method instead is preferred.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the collection to replace. The bounds of
+  ///     the range must be valid indices of the collection. **If `newElements`
+  ///     is empty, then the range must not be equivalent to the full unbounded
+  ///     range of indices of the collection.**
+  ///   - newElements: The new elements to add to the collection.
+  @inlinable
+  internal mutating func replaceSubrange<C: Collection>(
+    _ subrange: Range<Int>, with newElements: __owned C
+  ) where C.Element == UInt {
+    guard !newElements.isEmpty else {
+      removeSubrange(subrange)
+      return
+    }
+    switch (subrange.lowerBound, subrange.upperBound) {
+    case (0, 0):
+      _rest.insert(_low, at: 0)
+      _low = newElements.first!
+      _rest.insert(contentsOf: newElements.dropFirst(), at: 0)
+    case (0, let upperBound):
+      _low = newElements.first!
+      _rest.replaceSubrange(0..<(upperBound - 1), with: newElements.dropFirst())
+    case (let lowerBound, let upperBound):
+      _rest.replaceSubrange(
+        (lowerBound - 1)..<(upperBound - 1), with: newElements)
+    }
+  }
+  
+  /// Prepares the collection to store the specified number of elements, when
+  /// doing so is appropriate for the underlying type.
+  ///
+  /// If you are adding a known number of elements to a collection, use this
+  /// method to avoid multiple reallocations.
+  ///
+  /// - Parameter n: The requested number of elements to store.
+  @inlinable
+  internal mutating func reserveCapacity(_ n: Int) {
+    if n > 0 { _rest.reserveCapacity(n &- 1) }
+  }
+  
+  /// Creates a new collection containing the specified number of a single,
+  /// repeated value.
+  ///
+  /// - Parameters:
+  ///   - repeatedValue: The element to repeat.
+  ///   - count: The number of times to repeat the value passed in the
+  ///     `repeating` parameter. `count` must be **one** or greater.
+  @inlinable
+  internal init(repeating repeatedValue: UInt, count: Int) {
+    _low = repeatedValue
+    _rest = [UInt](repeating: repeatedValue, count: count - 1)
+  }
+  
+  /// Creates a new instance of a collection containing the elements of a
+  /// **nonempty collection**.
+  ///
+  /// Users expect `Self(collection).count == collection.count`, but we cannot
+  /// create an empty collection of type `BigInt._Significand`.
+  ///
+  /// - Parameter elements: The **collection** of elements for the new
+  ///   collection. `elements` must be **nonempty**.
+  @inlinable
+  internal init<C: Collection>(_ elements: C) where C.Element == UInt {
+    _low = elements.first!
+    _rest = [UInt](elements.dropFirst())
+  }
+  
+  /// Creates a new instance of a collection containing the elements of a
+  /// **nonempty slice**.
+  ///
+  /// Users expect `Self(slice).count == slice.count`, but we cannot create an
+  /// empty collection of type `BigInt._Significand`.
+  ///
+  /// - Parameter elements: The **slice** containing elements for the new
+  ///   collection. `elements` must be **nonempty**.
+  @inlinable
+  internal init(_ elements: Slice<Self>) {
+    if elements.startIndex == elements.base.startIndex
+      && elements.endIndex == elements.base.endIndex {
+      self = elements.base
+    } else {
+      _low = elements.first!
+      _rest = [UInt](elements.dropFirst())
+    }
+  }
+  
+  /// Adds an element to the end of the collection.
+  ///
+  /// If the collection does not have sufficient capacity for another element,
+  /// additional storage is allocated before appending `newElement`.
+  ///
+  /// - Parameter newElement: The element to append to the collection.
+  @inlinable
+  internal mutating func append(_ newElement: __owned UInt) {
+    _rest.append(newElement)
+  }
+  
+  /// Adds the elements of a sequence or collection to the end of this
+  /// collection.
+  ///
+  /// The collection being appended to allocates any additional necessary
+  /// storage to hold the new elements.
+  ///
+  /// - Parameter newElements: The elements to append to the collection.
+  @inlinable
+  internal mutating func append<S: Sequence>(
+    contentsOf newElements: __owned S
+  ) where S.Element == UInt {
+    _rest.append(contentsOf: newElements)
+  }
+  
+  /// Inserts a new element into the collection at the specified position.
+  ///
+  /// The new element is inserted before the element currently at the
+  /// specified index. If you pass the collection's `endIndex` property as
+  /// the `index` parameter, the new element is appended to the
+  /// collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter newElement: The new element to insert into the collection.
+  /// - Parameter i: The position at which to insert the new element.
+  ///   `index` must be a valid index into the collection.
+  @inlinable
+  internal mutating func insert(_ newElement: __owned UInt, at i: Int) {
+    if i != 0 {
+      _rest.insert(newElement, at: i - 1)
+    } else {
+      _rest.insert(_low, at: 0)
+      _low = newElement
+    }
+  }
+  
+  /// Inserts the elements of a sequence into the collection at the specified
+  /// position.
+  ///
+  /// The new elements are inserted before the element currently at the
+  /// specified index. If you pass the collection's `endIndex` property as the
+  /// `index` parameter, the new elements are appended to the collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter newElements: The new elements to insert into the collection.
+  /// - Parameter i: The position at which to insert the new elements. `index`
+  ///   must be a valid index of the collection.
+  @inlinable
+  internal mutating func insert<C: Collection>(
+    contentsOf newElements: __owned C, at i: Int
+  ) where C.Element == UInt {
+    if i != 0 {
+      _rest.insert(contentsOf: newElements, at: i - 1)
+    } else if !newElements.isEmpty {
+      _rest.insert(_low, at: 0)
+      _low = newElements.first!
+      _rest.insert(contentsOf: newElements.dropFirst(), at: 0)
+    }
+  }
+  
+  /// Removes and returns the element at the specified position.
+  ///
+  /// **The collection must have more than one element.**
+  ///
+  /// All the elements following the specified position are moved to close the
+  /// gap.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter i: The position of the element to remove. `i` must be a valid
+  ///   index of the collection that is not equal to the collection's end index.
+  /// - Returns: The removed element.
+  @inlinable
+  @discardableResult
+  internal mutating func remove(at i: Int) -> UInt {
+    return i == 0 ? removeFirst() : _rest.remove(at: i - 1)
+  }
+  
+  /// Removes and returns the first element of the collection.
+  ///
+  /// The collection must **have more than one element**.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Returns: The removed element.
+  @inlinable
+  @discardableResult
+  internal mutating func removeFirst() -> UInt {
+    let temporary = _low
+    _low = _rest.removeFirst()
+    return temporary
+  }
+  
+  /// Removes the specified number of elements from the beginning of the
+  /// collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter k: The number of elements to remove from the collection.
+  ///   `k` must be greater than or equal to zero and must not exceed **or
+  ///   equal** the number of elements in the collection.
+  @inlinable
+  internal mutating func removeFirst(_ k: Int) {
+    if k == 0 {
+      return
+    } else if k == 1 {
+      _low = _rest.removeFirst()
+    } else {
+      _low = _rest[k - 1]
+      _rest.removeFirst(k)
+    }
+  }
+  
+  /// Removes and returns the last element of the collection.
+  ///
+  /// The collection must **have more than one element**.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Returns: The last element of the collection.
+  @inlinable
+  @discardableResult
+  internal mutating func removeLast() -> UInt {
+    return _rest.removeLast()
+  }
+  
+  /// Removes the specified number of elements from the end of the collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter k: The number of elements to remove from the collection.
+  ///   `k` must be greater than or equal to zero and must not exceed **or
+  ///   equal** the number of elements in the collection.
+  @inlinable
+  internal mutating func removeLast(_ k: Int) {
+    _rest.removeLast(k)
+  }
+  
+  /// Removes the specified subrange of elements from the collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter bounds: The subrange of the collection to remove. The bounds
+  ///   of the range must be valid indices of the collection **and the range
+  ///   must not be equivalent to the full unbounded range of indices of the
+  ///   collection**.
+  @inlinable
+  internal mutating func removeSubrange(_ bounds: Range<Int>) {
+    let (lowerBound, upperBound) = (bounds.lowerBound, bounds.upperBound)
+    if lowerBound == 0 {
+      removeFirst(upperBound)
+    } else {
+      _rest.removeSubrange((lowerBound - 1)..<(upperBound - 1))
+    }
+  }
+  
+  /// Removes the specified subrange of elements from the collection.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameter bounds: The subrange of the collection to remove. The bounds
+  ///   of the range must be valid indices of the collection **and the range
+  ///   must not be equivalent to the full unbounded range of indices of the
+  ///   collection**.
+  @inlinable
+  internal mutating func removeSubrange<R: RangeExpression>(
+    _ bounds: R
+  ) where R.Bound == Int {
+    removeSubrange(bounds.relative(to: self))
+  }
+  
+  /// Replaces the specified subrange of elements with the given collection.
+  ///
+  /// This method has the effect of removing the specified range of elements
+  /// from the collection and inserting the new elements at the same location.
+  /// The number of new elements need not match the number of elements being
+  /// removed.
+  ///
+  /// If you pass a zero-length range as the `subrange` parameter, this method
+  /// inserts the elements of `newElements` at `subrange.startIndex`. Calling
+  /// the `insert(contentsOf:at:)` method instead is preferred.
+  ///
+  /// Likewise, if you pass a zero-length collection as the `newElements`
+  /// parameter, this method removes the elements in the given subrange
+  /// without replacement. Calling the `removeSubrange(_:)` method instead is
+  /// preferred.
+  ///
+  /// Calling this method may invalidate any existing indices for use with this
+  /// collection.
+  ///
+  /// - Parameters:
+  ///   - subrange: The subrange of the collection to replace. The bounds of
+  ///     the range must be valid indices of the collection. **If `newElements`
+  ///     is empty, then the range must not be equivalent to the full unbounded
+  ///     range of indices of the collection.**
+  ///   - newElements: The new elements to add to the collection.
+  @inlinable
+  internal mutating func replaceSubrange<C: Collection, R: RangeExpression>(
+    _ subrange: R, with newElements: __owned C
+  ) where C.Element == UInt, R.Bound == Int {
+    replaceSubrange(subrange.relative(to: self), with: newElements)
+  }
+}
+
+extension BigInt._Significand: Hashable { }
+
+/// Nota bene:
+/// While operations implemented on `BigInt` expect inputs that are normalized
+/// and produce outputs that are normalized, operations implemented here should
+/// tolerate input significands with extraneous leading or trailing zeros and do
+/// not need to delete them from their output.
+extension BigInt._Significand {
+  /// Replaces this significand with its radix complement and returns a Boolean
+  /// value indicating whether overflow occurred.
+  ///
+  /// - Parameter radix: The radix to use in computing the radix complement.
+  ///   This method is currently implemented only for radix 2 (i.e., two's
+  ///   complement).
+  /// - Returns: A Boolean value indicating whether overflow occurred, in which
+  ///   case `self` is the partial value (without the overflowing bit).
+  @inlinable
+  @discardableResult
+  internal mutating func complement(radix: Int) -> /* overflow: */ Bool {
+    precondition(radix == 2)
+    var i = 0
+    var overflow = true
+    while overflow && i < count {
+      self[i]._invert()
+      overflow = (self[i] == UInt.max)
+      self[i] &+= 1
+      i &+= 1
+    }
+    while i < count {
+      self[i]._invert()
+      i &+= 1
+    }
+    return overflow
+  }
+  
+  /// Increments this significand by one.
+  @inlinable
+  internal mutating func increment() {
+    var overflow = true
+    for i in 0..<count {
+      if overflow {
+        overflow = (self[i] == UInt.max)
+        self[i] &+= 1
+      } else {
+        break
+      }
+    }
+    if overflow { append(1) }
+  }
+  
+  /// Decrements this significand by one and returns a Boolean value indicating
+  /// whether overflow occurred.
+  ///
+  /// - Returns: A Boolean value indicating whether overflow occurred (i.e.,
+  ///   whether the logical result is less than zero), in which case `self` is
+  ///   the partial value (or two's complement representation of the logical
+  ///   result).
+  @inlinable
+  @discardableResult
+  internal mutating func decrement() -> /* overflow: */ Bool {
+    var overflow = true
+    for i in 0..<count {
+      if overflow {
+        overflow = (self[i] == 0)
+        self[i] &-= 1
+      } else {
+        break
+      }
+    }
+    return overflow
+  }
+  
+  // @inlinable
+  internal mutating func add(_ other: Self, exponent: Int = 0) {
+    let counts = (count, other.count + exponent)
+    var i = exponent
+    var overflow = false
+    while i < Swift.min(counts.0, counts.1) {
+      let temporary = self[i].addingReportingOverflow(other[i &- exponent])
+      if overflow {
+        overflow = temporary.overflow || (temporary.partialValue == UInt.max)
+        self[i] = temporary.partialValue &+ 1
+      } else {
+        overflow = temporary.overflow
+        self[i] = temporary.partialValue
+      }
+      i &+= 1
+    }
+    if counts.0 >= counts.1 {
+      while i < counts.0 {
+        if overflow {
+          overflow = (self[i] == UInt.max)
+          self[i] &+= 1
+        } else {
+          break
+        }
+        i &+= 1
+      }
+    } else {
+      if i > counts.0 {
+        assert(i == exponent)
+        insert(contentsOf: repeatElement(0, count: i &- counts.0), at: counts.0)
+      }
+      while overflow && i < counts.1 {
+        let temporary = other[i &- exponent]
+        overflow = (temporary == UInt.max)
+        append(temporary &+ 1)
+        i &+= 1
+      }
+      while i < counts.1 {
+        append(other[i &- exponent])
+        i &+= 1
+      }
+    }
+    if overflow { append(1) }
+  }
+  
+  // @inlinable
+  @discardableResult
+  internal mutating func subtract(
+    _ other: Self, exponent: Int = 0
+  ) -> /* overflow: */ Bool {
+    let counts = (count, other.count + exponent)
+    var i = exponent
+    var overflow = false
+    while i < Swift.min(counts.0, counts.1) {
+      let temporary = self[i].subtractingReportingOverflow(other[i &- exponent])
+      if overflow {
+        overflow = temporary.overflow || (temporary.partialValue == 0)
+        self[i] = temporary.partialValue &- 1
+      } else {
+        overflow = temporary.overflow
+        self[i] = temporary.partialValue
+      }
+      i &+= 1
+    }
+    if counts.0 >= counts.1 {
+      while i < counts.0 {
+        if overflow {
+          overflow = (self[i] == 0)
+          self[i] &-= 1
+        } else {
+          break
+        }
+        i &+= 1
+      }
+    } else {
+      if i > counts.0 {
+        assert(i == exponent)
+        insert(contentsOf: repeatElement(0, count: i &- counts.0), at: counts.0)
+      }
+      while !overflow && i < counts.1 {
+        let temporary = other[i &- exponent]
+        overflow = (temporary != 0)
+        append(0 &- temporary)
+        i &+= 1
+      }
+      while i < counts.1 {
+        append(~other[i &- exponent]) // Note that `~x == 0 &- x &- 1`.
+        i &+= 1
+      }
+    }
+    return overflow
+  }
+  
+  // @inlinable
+  internal mutating func multiply(by other: UInt) {
+    var carry = 0 as UInt
+    for i in 0..<count {
+      let temporary = self[i].multipliedFullWidth(by: other)
+      let overflow: Bool
+      (self[i], overflow) = temporary.low.addingReportingOverflow(carry)
+      carry = overflow ? temporary.high + 1 : temporary.high
+    }
+    if carry != 0 { append(carry) }
+  }
+  
+  // @inlinable
+  internal func multiplying(by other: Self) -> Self {
+    var result = Self()
+    result.reserveCapacity(count + other.count)
+    for i in 0..<other.count {
+      var temporary = self
+      temporary.multiply(by: other[i])
+      result.add(temporary, exponent: i)
+    }
+    return result
+  }
+  
+  // Nota bene: `karatsubaThreshold` is defined in terms of `m`, the count (in
+  // words) of the lower half of each operand.
+  // @inlinable
+  internal func multiplying(by other: Self, karatsubaThreshold: Int) -> Self {
+    func add(_ lhs: Slice<Self>, _ rhs: Slice<Self>) -> Self {
+      // Recall that we have a precondition for `Self<C: Collection>(_: C)` that
+      // the argument not be empty.
+      if lhs.isEmpty { return rhs.isEmpty ? Self() : Self(rhs) }
+      if rhs.isEmpty { return Self(lhs) }
+      
+      var result = Self(lhs)
+      result.add(Self(rhs))
+      return result
+    }
+    
+    func multiply(_ lhs: Slice<Self>, _ rhs: Slice<Self>) -> Self {
+      let m = (Swift.max(lhs.count, rhs.count) + 1) / 2
+      guard m >= karatsubaThreshold else {
+        if lhs.isEmpty || rhs.isEmpty { return Self() }
+        return Self(lhs).multiplying(by: Self(rhs))
+      }
+      
+      let (x0, x1) = (lhs.prefix(m), lhs.dropFirst(m))
+      let (y0, y1) = (rhs.prefix(m), rhs.dropFirst(m))
+
+      var z0 = multiply(x0, y0)
+      let z2 = multiply(x1, y1)
+      
+      let a = add(x0, x1)
+      let b = add(y0, y1)
+      var z1 = multiply(a[...], b[...])
+      z1.subtract(z2)
+      z1.subtract(z0)
+      
+      z0.reserveCapacity(lhs.count + rhs.count)
+      z0.add(z1, exponent: m)
+      z0.add(z2, exponent: m * 2)
+      return z0
+    }
+    
+    return multiply(self[...], other[...])
+  }
+  
+  // @inlinable
+  @discardableResult
+  internal mutating func divide(by other: UInt) -> /* remainder: */ Self {
+    if other == 1 { return Self() }
+    var remainder = 0 as UInt
+    for i in (0..<count).reversed() {
+      (self[i], remainder) = other.dividingFullWidth((remainder, self[i]))
+    }
+    return Self(remainder)
+  }
+  
+  // @inlinable
+  @discardableResult
+  internal func quotientAndRemainder(
+    dividingBy other: Self
+  ) -> (quotient: Self, remainder: Self) {
+    if other.count == 1 {
+      var x = self
+      let remainder = x.divide(by: other._low)
+      return (quotient: x, remainder: remainder)
+    }
+    fatalError("Not implemented")
+  }
+}

--- a/Sources/BigIntModule/BigInt.swift
+++ b/Sources/BigIntModule/BigInt.swift
@@ -1,0 +1,866 @@
+/// An arbitrarily large signed integer.
+///
+/// Because there is no logical minimum or maximum value representable as a
+/// `BigInt`, operations may take a long time to complete and results may
+/// exceed available memory.
+///
+/// Storage
+/// =======
+///
+/// Internally, a `BigInt` value `x` is represented by its signum, significand,
+/// and exponent using the following notional formula:
+///
+/// ```
+/// x == _signum * _significand << (UInt.bitWidth * _exponent)
+/// ```
+///
+/// Each integer value has exactly one normalized representation, where the
+/// significand--a nonempty collection of the significant digits of the value's
+/// magnitude stored in words of type `UInt`--is trimmed of all leading and
+/// trailing words that are zero to a minimum count of one word.
+@frozen
+public struct BigInt {
+  /// The combination field.
+  ///
+  /// The signum and exponent of this value are stored in the combination field
+  /// as follows:
+  ///
+  /// ```
+  /// _combination = _signum * (_exponent + 1)
+  /// ```
+  @usableFromInline
+  internal var _combination: Int
+  
+  /// The signum of this value, expressed as an `Int`.
+  ///
+  /// Given a value `x`, `x._signum` is `-1` if `x` is less than zero and `1` if
+  /// `x` is greater than zero; otherwise, `0`.
+  ///
+  /// It is an internal invariant that a value with nonzero significand should
+  /// not have `_signum` equal to zero, even when it is not normalized, since a
+  /// nonzero magnitude with unknown sign does not represent a unique value.
+  @inlinable
+  internal var _signum: Int { _combination.signum() }
+  
+  /// The exponent of this value, expressed as an `Int`.
+  ///
+  /// Given a value `x`, its magnitude can be computed by the following notional
+  /// formula:
+  ///
+  /// ```
+  /// let magnitude = x._significand << (UInt.bitWidth * x._exponent)
+  /// ```
+  ///
+  /// The exponent obtained in this manner is also the zero-based index of the
+  /// first (lowest) nonzero word, enabling random access of the words in the
+  /// two's complement representation of a value in constant time.
+  ///
+  /// Edge case: if `x` is zero, `x._exponent` is `-1`.
+  @inlinable
+  internal var _exponent: Int { abs(_combination) &- 1 }
+  
+  /// The significand, a nonempty collection of the significant digits of this
+  /// value's magnitude stored in words of type `UInt`.
+  ///
+  /// The first element of the collection is the lowest word.
+  @usableFromInline
+  internal var _significand: _Significand
+  
+  /// Normalizes the internal representation of this value.
+  ///
+  /// When a value is normalized, `_signum` is set to zero if `_significand`
+  /// contains only words that are zero. Otherwise, leading (i.e., the highest)
+  /// zero words are trimmed. Then, trailing (i.e., the lowest) zero words are
+  /// trimmed and `_exponent` is incremented for each word removed.
+  ///
+  /// It is an internal invariant that a value with nonzero significand should
+  /// not have `_signum` equal to zero, even when it is not normalized, since a
+  /// nonzero magnitude with unknown sign does not represent a unique value.
+  @inlinable
+  internal mutating func _normalize() {
+    guard let i = _significand.firstIndex(where: { $0 != 0 }) else {
+      _combination = 0
+      _significand = _Significand()
+      return
+    }
+    assert(_combination != 0)
+    
+    let j = 1 &+ _significand.lastIndex(where: { $0 != 0 })!
+    _significand.removeLast(_significand.count &- j)
+    
+    _significand.removeFirst(i)
+    if _combination < 0 { _combination -= i } else { _combination += i }
+  }
+  
+  /// Creates a `BigInt` with the given combination field and significand.
+  ///
+  /// Nota bene:
+  /// No normalization is performed for the created value.
+  ///
+  /// - Parameters:
+  ///   - _combination: The combination field of the created value, equivalent
+  ///     to `_signum * (_exponent + 1)`.
+  ///     If the significand is nonzero, then the signum (and therefore the
+  ///     combination field) must also be nonzero.
+  ///   - significand: The significand of the created value.
+  @inlinable
+  internal init(_combination: Int, significand: _Significand) {
+    self._combination = _combination
+    _significand = significand
+  }
+}
+
+extension BigInt: Hashable, Comparable {
+  // We must override the default implementation of `==` that comes with
+  // `Strideable` conformance. (`BinaryInteger` refines `Strideable`.)
+  @inlinable
+  public static func == (lhs: BigInt, rhs: BigInt) -> Bool {
+    lhs._combination == rhs._combination &&
+      (lhs._combination == 0 || lhs._significand == rhs._significand)
+  }
+  
+  @inlinable
+  public static func < (lhs: BigInt, rhs: BigInt) -> Bool {
+    if lhs._combination == 0 { return rhs._combination > 0 }
+    if rhs._combination == 0 { return lhs._combination < 0 }
+    if lhs._signum != rhs._signum { return lhs._signum < rhs._signum }
+
+    let words = (lhs.words, rhs.words)
+    let counts = (words.0.count, words.1.count)
+    if counts.0 != counts.1 {
+      return (lhs._signum < 0) != (counts.0 < counts.1)
+    }
+    
+    let exponent = Swift.min(lhs._exponent, rhs._exponent)
+    for i in (exponent..<counts.0).reversed() {
+      let (left, right) = (words.0[i], words.1[i])
+      if left != right { return left < right }
+    }
+    return false
+  }
+}
+
+extension BigInt: ExpressibleByIntegerLiteral {
+  @inlinable
+  public init(integerLiteral value: Int) {
+    _combination = value.signum()
+    _significand = _Significand(value.magnitude)
+  }
+}
+
+extension BigInt: AdditiveArithmetic {
+  @inlinable
+  public init() {
+    _combination = 0
+    _significand = _Significand()
+  }
+  
+  @inlinable
+  public static var zero: BigInt { BigInt() }
+  
+  // @inlinable
+  public static func += (lhs: inout BigInt, rhs: BigInt) {
+    guard lhs._combination != 0 else {
+      lhs = rhs
+      return
+    }
+    guard rhs._combination != 0 else { return }
+    guard lhs._signum == rhs._signum else {
+      lhs -= -rhs
+      return
+    }
+    
+    let exponents = (lhs._exponent, rhs._exponent)
+    let counts =
+      (lhs._significand.count + exponents.0,
+       rhs._significand.count + exponents.1)
+    if counts.0 < counts.1 {
+      lhs._significand.reserveCapacity(
+        lhs._significand.count + (counts.1 &- counts.0) + 1)
+    }
+    
+    if exponents.0 > exponents.1 {
+      lhs._combination = lhs._signum * (exponents.1 + 1)
+      lhs._significand.insert(
+        contentsOf: repeatElement(0, count: exponents.0 &- exponents.1), at: 0)
+      lhs._significand.add(rhs._significand, exponent: 0)
+    } else {
+      lhs._significand.add(
+        rhs._significand, exponent: exponents.1 &- exponents.0)
+    }
+    lhs._normalize()
+  }
+
+  @inlinable
+  public static func + (lhs: BigInt, rhs: BigInt) -> BigInt {
+    var result = lhs
+    result += rhs
+    return result
+  }
+
+  // @inlinable
+  public static func -= (lhs: inout BigInt, rhs: BigInt) {
+    guard lhs._combination != 0 else {
+      lhs = -rhs
+      return
+    }
+    guard rhs._combination != 0 else { return }
+    guard lhs._signum == rhs._signum else {
+      lhs += -rhs
+      return
+    }
+    
+    let exponents = (lhs._exponent, rhs._exponent)
+    let counts =
+      (lhs._significand.count + exponents.0,
+       rhs._significand.count + exponents.1)
+    if counts.0 < counts.1 {
+      lhs._significand.reserveCapacity(
+        lhs._significand.count + (counts.1 &- counts.0))
+    }
+    
+    let overflow: Bool
+    if exponents.0 > exponents.1 {
+      lhs._combination = lhs._signum * (exponents.1 + 1)
+      lhs._significand.insert(
+        contentsOf: repeatElement(0, count: exponents.0 &- exponents.1), at: 0)
+      overflow = lhs._significand.subtract(rhs._significand, exponent: 0)
+    } else {
+      overflow = lhs._significand.subtract(
+        rhs._significand, exponent: exponents.1 &- exponents.0)
+    }
+    if overflow {
+      lhs._combination.negate()
+      lhs._significand.complement(radix: 2)
+    }
+    lhs._normalize()
+  }
+  
+  @inlinable
+  public static func - (lhs: BigInt, rhs: BigInt) -> BigInt {
+    var result = lhs
+    result -= rhs
+    return result
+  }
+}
+
+extension BigInt: SignedNumeric {
+  @inlinable
+  public init?<T: BinaryInteger>(exactly source: T) {
+    self.init(source)
+  }
+
+  @inlinable
+  public var magnitude: BigInt { _combination < 0 ? -self : self }
+  
+  @inlinable
+  public mutating func negate() { _combination.negate() }
+
+  // @inlinable
+  public static func * (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard lhs._combination != 0 && rhs._combination != 0 else {
+      return BigInt()
+    }
+    let combination =
+      lhs._signum * rhs._signum * (lhs._exponent + rhs._exponent + 1)
+    let significand =
+      lhs._significand.multiplying(by: rhs._significand, karatsubaThreshold: 8)
+    var result = BigInt(_combination: combination, significand: significand)
+    result._normalize()
+    return result
+  }
+
+  @inlinable
+  public static func *= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs * rhs
+  }
+}
+
+extension BigInt: BinaryInteger {
+  @inlinable
+  public var words: Words { Words(self) }
+
+  @inlinable
+  public var bitWidth: Int {
+    if _combination == 0 { return 0 }
+    let lastIndex = _significand.count &- 1
+    let highWord = _significand[lastIndex]
+    let magnitudeBitWidth =
+      UInt.bitWidth * (_exponent + lastIndex)
+        + (UInt.bitWidth &- highWord.leadingZeroBitCount)
+    // For a positive value:
+    // We need to add one leading zero bit for a signed representation.
+    if _combination > 0 { return magnitudeBitWidth + 1 }
+    // For a negative value:
+    // The two's complement of a magnitude has the same bit width as that of the
+    // magnitude itself if and only if the magnitude is a power of two.
+    // Otherwise, we need one additional bit to fit the two's complement.
+    //
+    // (Note that `(x & (x &- 1)) == 0` is a method of determining if `x` is
+    // a power of two.)
+    return lastIndex == 0 && (highWord & (highWord &- 1)) == 0
+      ? magnitudeBitWidth
+      : magnitudeBitWidth + 1
+  }
+
+  @inlinable
+  public var trailingZeroBitCount: Int {
+    if _combination == 0 { return 0 }
+    // The trailing zero bit count of a value and its two's complement are
+    // always the same.
+    return _exponent * UInt.bitWidth + _significand[0].trailingZeroBitCount
+  }
+  
+  @inlinable
+  public func signum() -> BigInt { BigInt(_signum) }
+  
+  @inlinable
+  public init<T: BinaryInteger>(_ source: T) {
+    if let temporary = UInt(exactly: source) {
+      _combination = temporary == 0 ? 0 : 1
+      _significand = _Significand(temporary)
+    } else {
+      _combination = Int(source.signum())
+      _significand = _Significand(source.magnitude.words)
+      _normalize()
+    }
+  }
+  
+  @inlinable
+  public init<T: BinaryInteger>(clamping source: T) {
+    self.init(source)
+  }
+  
+  @inlinable
+  public init<T: BinaryInteger>(truncatingIfNeeded source: T) {
+    self.init(source)
+  }
+  
+  @usableFromInline // @inlinable
+  internal static func _convert<T: BinaryFloatingPoint>(
+    from source: T
+  ) -> (value: BigInt?, exact: Bool) {
+    // This implementation is adapted from its counterpart implemented for
+    // `FixedWidthInteger` types in the standard library by the present author.
+    guard !source.isZero else { return (0, true) }
+    guard source.isFinite else { return (nil, false) }
+    let exponent = source.exponent
+    let minBitWidth = source.significandWidth
+    let isExact = (minBitWidth <= exponent)
+    let bitPattern = source.significandBitPattern
+    // `RawSignificand.bitWidth` is not available if `RawSignificand` does not
+    // conform to `FixedWidthInteger`; we can compute this value as follows if
+    // `source` is finite:
+    let bitWidth = minBitWidth &+ bitPattern.trailingZeroBitCount
+    let shift = exponent - T.Exponent(bitWidth)
+    let shiftedBitPattern = BigInt(bitPattern) << shift
+    let magnitude = ((1 as BigInt) << exponent) | shiftedBitPattern
+    return (source < 0 ? -magnitude : magnitude, isExact)
+  }
+  
+  @inlinable
+  public init?<T: BinaryFloatingPoint>(exactly source: T) {
+    let (temporary, exact) = BigInt._convert(from: source)
+    guard exact, let value = temporary else {
+      return nil
+    }
+    self = value
+  }
+
+  @inlinable
+  public init<T: BinaryFloatingPoint>(_ source: T) {
+    guard let value = BigInt._convert(from: source).value else {
+      fatalError(
+        "\(T.self) value cannot be converted to BigInt because it is infinite or NaN")
+    }
+    self = value
+  }
+
+  @inlinable
+  public static var isSigned: Bool { true }
+
+  // @inlinable
+  public static func / (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard rhs._combination != 0 else { fatalError("Division by zero") }
+    guard abs(rhs) <= abs(lhs) else { return 0 }
+    
+    //TODO: Implement division. For now, this is a skeleton placeholder.
+    if lhs._exponent == rhs._exponent {
+      let combination = lhs._signum * rhs._signum
+      let (significand, _) =
+        lhs._significand.quotientAndRemainder(dividingBy: rhs._significand)
+      var result = BigInt(_combination: combination, significand: significand)
+      result._normalize()
+      return result
+    }
+    fatalError("Not implemented")
+  }
+
+  // @inlinable
+  public static func /= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs / rhs
+  }
+
+  // @inlinable
+  public static func % (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard rhs._combination != 0 else { fatalError("Division by zero") }
+    guard abs(rhs) <= abs(lhs) else { return lhs }
+    
+    //TODO: Implement remainder. For now, this is a skeleton placeholder.
+    if lhs._exponent == rhs._exponent {
+      let combination = lhs._combination * rhs._signum
+      let (_, significand) =
+        lhs._significand.quotientAndRemainder(dividingBy: rhs._significand)
+      var result = BigInt(_combination: combination, significand: significand)
+      result._normalize()
+      return result
+    }
+    fatalError("Not implemented")
+  }
+
+  // @inlinable
+  public static func %= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs % rhs
+  }
+
+  // @inlinable
+  public static func & (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard lhs._combination != 0 && rhs._combination != 0 else { return 0 }
+    
+    let signum = lhs._signum < 0 && rhs._signum < 0 ? -1 : 1
+    let exponent = Swift.max(lhs._exponent, rhs._exponent)
+    
+    let words = (lhs.words, rhs.words)
+    let count = lhs._signum > 0 && rhs._signum > 0
+      ? Swift.min(words.0.count, words.1.count)
+      : Swift.max(words.0.count, words.1.count)
+    
+    guard exponent < count else { return 0 }
+    var rest: [UInt] = (exponent..<count).map { idx in
+      words.0[idx] & words.1[idx]
+    }
+    let low = rest.removeFirst()
+    
+    var significand = _Significand(low, rest)
+    if signum < 0 {
+      let overflow = significand.complement(radix: 2)
+      assert(!overflow)
+    }
+    
+    var result =
+      BigInt(_combination: signum * (exponent + 1), significand: significand)
+    result._normalize()
+    return result
+  }
+  
+  @inlinable
+  public static func &= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs & rhs
+  }
+
+  // @inlinable
+  public static func | (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard lhs._combination != 0 else { return rhs._signum == 0 ? 0 : rhs }
+    guard rhs._combination != 0 else { return lhs }
+    
+    let signum = (lhs._signum > 0 && rhs._signum > 0) ? 1 : -1
+    let exponent = Swift.min(lhs._exponent, rhs._exponent)
+    
+    let words = (lhs.words, rhs.words)
+    let count = lhs._signum < 0 && rhs._signum < 0
+      ? Swift.min(words.0.count, words.1.count)
+      : Swift.max(words.0.count, words.1.count)
+    
+    assert(exponent < count)
+    var rest: [UInt] = (exponent..<count).map { idx in
+      words.0[idx] | words.1[idx]
+    }
+    let low = rest.removeFirst()
+    
+    var significand = _Significand(low, rest)
+    if signum < 0 {
+      let overflow = significand.complement(radix: 2)
+      assert(!overflow)
+    }
+    
+    var result =
+      BigInt(_combination: signum * (exponent + 1), significand: significand)
+    result._normalize()
+    return result
+  }
+  
+  @inlinable
+  public static func |= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs | rhs
+  }
+
+  // @inlinable
+  public static func ^ (lhs: BigInt, rhs: BigInt) -> BigInt {
+    guard lhs._combination != 0 else { return rhs._signum == 0 ? 0 : rhs }
+    guard rhs._combination != 0 else { return lhs }
+    
+    let signum = (lhs._signum < 0) != (rhs._signum < 0) ? -1 : 1
+    let exponent = Swift.min(lhs._exponent, rhs._exponent)
+    
+    let words = (lhs.words, rhs.words)
+    let count = Swift.max(words.0.count, words.1.count)
+    
+    assert(exponent < count)
+    var rest: [UInt] = (exponent..<count).map { idx in
+      words.0[idx] ^ words.1[idx]
+    }
+    let low = rest.removeFirst()
+    
+    var significand = _Significand(low, rest)
+    if signum < 0 {
+      let overflow = significand.complement(radix: 2)
+      assert(!overflow)
+    }
+    
+    var result =
+      BigInt(_combination: signum * (exponent + 1), significand: significand)
+    result._normalize()
+    return result
+  }
+  
+  @inlinable
+  public static func ^= (lhs: inout BigInt, rhs: BigInt) {
+    lhs = lhs ^ rhs
+  }
+  
+  // @inlinable
+  public static func <<= <RHS: BinaryInteger>(lhs: inout BigInt, rhs: RHS) {
+    guard lhs._combination != 0 && rhs != 0 else { return }
+    guard rhs > 0 else {
+      lhs >>= 0 - rhs
+      return
+    }
+    
+    let quotient, remainder: Int
+    if let rhs = Int(exactly: rhs) {
+      (quotient, remainder) =
+        rhs.quotientAndRemainder(dividingBy: UInt.bitWidth)
+    } else {
+      let temporary = rhs.quotientAndRemainder(dividingBy: RHS(UInt.bitWidth))
+      (quotient, remainder) = (Int(temporary.0), Int(temporary.1))
+    }
+    
+    if remainder != 0 {
+      var carry = 0 as UInt
+      for i in 0..<lhs._significand.count {
+        let temporary = lhs._significand[i]
+        lhs._significand[i] = temporary &<< remainder | carry
+        carry = temporary &>> (UInt.bitWidth &- remainder)
+      }
+      if carry != 0 { lhs._significand.append(carry) }
+    }
+    
+    if lhs._combination < 0 {
+      lhs._combination -= quotient
+    } else {
+      lhs._combination += quotient
+    }
+    lhs._normalize()
+  }
+  
+  // @inlinable
+  public static func >>= <RHS: BinaryInteger>(lhs: inout BigInt, rhs: RHS) {
+    guard lhs._combination != 0 && rhs != 0 else { return }
+    guard rhs > 0 else {
+      lhs <<= 0 - rhs
+      return
+    }
+    
+    var quotient, remainder: Int
+    if let rhs = Int(exactly: rhs) {
+      (quotient, remainder) =
+        rhs.quotientAndRemainder(dividingBy: UInt.bitWidth)
+    } else {
+      let temporary = rhs.quotientAndRemainder(dividingBy: RHS(UInt.bitWidth))
+      (quotient, remainder) = (Int(temporary.0), Int(temporary.1))
+    }
+    
+    // For a negative value:
+    // Shifting right is equivalent to dividing by the corresponding power of
+    // two and rounding down (towards negative infinity). Therefore, if we
+    // remove any nonzero bits, we'll need to subtract one (or, equivalently,
+    // add one to the magnitude) after shifting.
+    var rounding: Bool
+    if quotient > lhs._exponent {
+      quotient -= lhs._exponent
+      guard quotient < lhs._significand.count else {
+        lhs = lhs._combination < 0 ? -1 : 0
+        return
+      }
+      lhs._significand.removeFirst(quotient)
+      lhs._combination = lhs._signum
+      rounding = lhs._combination < 0
+    } else {
+      if lhs._combination < 0 {
+        lhs._combination += quotient
+      } else {
+        lhs._combination -= quotient
+      }
+      rounding = false
+    }
+
+    if remainder != 0 {
+      var carry = 0 as UInt
+      for i in (0..<lhs._significand.count).reversed() {
+        let temporary = lhs._significand[i]
+        lhs._significand[i] = temporary &>> remainder | carry
+        carry = temporary &<< (UInt.bitWidth &- remainder)
+      }
+      if carry != 0 {
+        if lhs._exponent != 0 {
+          lhs._significand.insert(carry, at: 0)
+          if lhs._combination < 0 {
+            lhs._combination += 1
+          } else {
+            lhs._combination -= 1
+          }
+        } else if lhs._combination < 0 {
+          rounding = true
+        }
+      }
+    }
+    if rounding { lhs._significand.increment() }
+    lhs._normalize()
+  }
+  
+  @inlinable
+  public static prefix func ~ (x: BigInt) -> BigInt { -(x + 1) }
+}
+
+extension BigInt: SignedInteger { }
+
+extension BigInt {
+  /// Creates a `BigInt` from the given words.
+  ///
+  /// - Parameter words: The words of an arbitrarily large signed integer. For a
+  ///   negative value, words are of the two’s complement representation.
+  //    `words` must be a nonempty collection.
+  @inlinable
+  public init<C: RandomAccessCollection>(
+    words: C
+  ) where C.Element == UInt, C.Index == Int {
+    precondition(!words.isEmpty, "Can't create value from an empty collection of words")
+    
+    let signum = Int(bitPattern: words.last!) < 0 ? -1 : 1
+    guard let exponent = words.firstIndex(where: { $0 != 0 }) else {
+      _combination = 0
+      _significand = _Significand()
+      return
+    }
+    _combination = signum * (exponent + 1)
+    
+    let count = words.count &- exponent
+    let low = signum < 0 ? ~words[exponent] &+ 1 : words[exponent]
+    var rest = [UInt]()
+    if count > 1 {
+      rest.reserveCapacity(count &- 1)
+      if signum < 0 {
+        for offset in 1..<count { rest.append(~words[exponent &+ offset]) }
+      } else {
+        for offset in 1..<count { rest.append(words[exponent &+ offset]) }
+      }
+    }
+    _significand = _Significand(low, rest)
+    
+    let j = 1 &+ _significand.lastIndex(where: { $0 != 0 })!
+    _significand.removeLast(_significand.count &- j)
+  }
+  
+  /// Creates a `BigInt` from the given words.
+  ///
+  /// - Parameter words: The words of an arbitrarily large signed integer. For a
+  ///   negative value, words are of the two’s complement representation.
+  @inlinable
+  public init(words: Words) {
+    self = words._value
+  }
+}
+
+/// Documentation is transposed from the corresponding random APIs implemented
+/// for `FixedWidthInteger` in the standard library.
+extension BigInt {
+  /// Returns a random value within the specified range, using the given
+  /// generator as a source for randomness.
+  ///
+  /// Use this method to generate an integer within a specific range when you
+  /// are using a custom random number generator.
+  ///
+  /// - Note: The algorithm used to create random values may change in a future
+  ///   version of Swift. If you're passing a generator that results in the
+  ///   same sequence of integer values each time you run your program, that
+  ///   sequence may change when your program is compiled using a different
+  ///   version of Swift.
+  ///
+  /// - Parameters:
+  ///   - range: The range in which to create a random value.
+  ///     `range` must not be empty.
+  ///   - generator: The random number generator to use when creating the
+  ///     new random value.
+  /// - Returns: A random value within the bounds of `range`.
+  @inlinable
+  public static func random<T: RandomNumberGenerator>(
+    in range: Range<BigInt>,
+    using generator: inout T
+  ) -> BigInt {
+    precondition(!range.isEmpty, "Can't get random value with an empty range")
+    let delta = range.upperBound - range.lowerBound
+    return range.lowerBound + generator._next(upperBound: delta)
+  }
+  
+  /// Returns a random value within the specified range.
+  ///
+  /// Use this method to generate an integer within a specific range.
+  ///
+  /// This method is equivalent to calling `random(in:using:)`, passing in the
+  /// system's default random generator.
+  ///
+  /// - Parameter range: The range in which to create a random value.
+  ///   `range` must not be empty.
+  /// - Returns: A random value within the bounds of `range`.
+  @inlinable
+  public static func random(in range: Range<BigInt>) -> BigInt {
+    var generator = SystemRandomNumberGenerator()
+    return BigInt.random(in: range, using: &generator)
+  }
+  
+  /// Returns a random value within the specified range, using the given
+  /// generator as a source for randomness.
+  ///
+  /// Use this method to generate an integer within a specific range when you
+  /// are using a custom random number generator.
+  ///
+  /// - Note: The algorithm used to create random values may change in a future
+  ///   version of Swift. If you're passing a generator that results in the
+  ///   same sequence of integer values each time you run your program, that
+  ///   sequence may change when your program is compiled using a different
+  ///   version of Swift.
+  ///
+  /// - Parameters:
+  ///   - range: The range in which to create a random value.
+  ///   - generator: The random number generator to use when creating the
+  ///     new random value.
+  /// - Returns: A random value within the bounds of `range`.
+  @inlinable
+  public static func random<T: RandomNumberGenerator>(
+    in range: ClosedRange<BigInt>,
+    using generator: inout T
+  ) -> BigInt {
+    let delta = range.upperBound - range.lowerBound + 1
+    return range.lowerBound + generator._next(upperBound: delta)
+  }
+  
+  /// Returns a random value within the specified range.
+  ///
+  /// Use this method to generate an integer within a specific range.
+  ///
+  /// This method is equivalent to calling `random(in:using:)`, passing in the
+  /// system's default random generator.
+  ///
+  /// - Parameter range: The range in which to create a random value.
+  /// - Returns: A random value within the bounds of `range`.
+  @inlinable
+  public static func random(in range: ClosedRange<BigInt>) -> BigInt {
+    var generator = SystemRandomNumberGenerator()
+    return Self.random(in: range, using: &generator)
+  }
+}
+
+extension BigInt: LosslessStringConvertible {
+  /// Creates a new integer value from the given string and radix.
+  ///
+  /// The string passed as `text` may begin with a plus or minus sign character
+  /// (`+` or `-`), followed by one or more numeric digits (`0-9`) or letters
+  /// (`a-z` or `A-Z`). Parsing of the string is case insensitive.
+  ///
+  /// If `text` is in an invalid format or contains characters that are out of
+  /// bounds for the given `radix`, the result is `nil`.
+  ///
+  /// - Parameters:
+  ///   - text: The ASCII representation of a number in the radix passed as
+  ///     `radix`.
+  ///   - radix: The radix, or base, to use for converting `text` to an integer
+  ///     value. `radix` must be in the range `2...36`. The default is 10.
+  // @inlinable
+  public init?<S: StringProtocol>(_ text: S, radix: Int = 10) {
+    precondition(radix >= 2 && radix <= 36, "Radix not in range 2...36")
+    
+    self = BigInt()
+    var negative = false
+    var iterator = text.unicodeScalars.makeIterator()
+    
+    var rune_ = iterator.next()
+    guard rune_ != nil else { return nil }
+    if rune_! == "-" {
+      negative = true
+      rune_ = iterator.next()
+    } else if rune_! == "+" {
+      rune_ = iterator.next()
+    }
+    
+    var chunk = ""
+    if radix == 2
+      || (radix == 4 && UInt.bitWidth % 2 == 0)
+      || (radix == 16 && UInt.bitWidth % 4 == 0) {
+      let size = UInt.bitWidth / radix._binaryLogarithm()
+      while let rune = rune_ {
+        guard rune.isASCII && rune != "+" && rune != "-" else { return nil }
+        if size == chunk.unicodeScalars.count {
+          guard let x = UInt(chunk, radix: radix) else { return nil }
+          self <<= UInt.bitWidth
+          if x != 0 { self += BigInt(x) }
+          chunk = ""
+        }
+        chunk.unicodeScalars.append(rune)
+        rune_ = iterator.next()
+      }
+      guard let x = UInt(chunk, radix: radix) else { return nil }
+      self <<= chunk.unicodeScalars.count * radix._binaryLogarithm()
+      if x != 0 { self += BigInt(x) }
+    } else {
+      var multiplier = 1
+      while let rune = rune_ {
+        guard rune.isASCII && rune != "+" && rune != "-" else { return nil }
+        let temporary = multiplier.multipliedReportingOverflow(by: radix)
+        if temporary.overflow {
+          guard let x = UInt(chunk, radix: radix) else { return nil }
+          self *= BigInt(multiplier)
+          if x != 0 { self += BigInt(x) }
+          chunk = ""
+          multiplier = radix
+        } else {
+          multiplier = temporary.partialValue
+        }
+        chunk.unicodeScalars.append(rune)
+        rune_ = iterator.next()
+      }
+      guard let x = UInt(chunk, radix: radix) else { return nil }
+      self *= BigInt(multiplier)
+      if x != 0 { self += BigInt(x) }
+    }
+    if negative { self.negate() }
+  }
+  
+  @inlinable
+  public init?(_ description: String) {
+    self.init(description, radix: 10)
+  }
+}
+
+extension BigInt: Codable {
+  // @inlinable
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode("\(self)")
+  }
+
+  // @inlinable
+  public init(from decoder: Decoder) throws {
+    let string = try decoder.singleValueContainer().decode(String.self)
+    self.init(string)!
+  }
+}

--- a/Sources/BigIntModule/BinaryInteger.swift
+++ b/Sources/BigIntModule/BinaryInteger.swift
@@ -1,0 +1,6 @@
+extension BinaryInteger {
+  @inlinable
+  internal mutating func _invert() {
+    self = ~self
+  }
+}

--- a/Sources/BigIntModule/README.md
+++ b/Sources/BigIntModule/README.md
@@ -1,0 +1,20 @@
+# Arbitrarily Large Signed Integers (BigInt)
+
+This module provides a `BigInt` number type:
+
+```swift
+1> import BigIntModule
+2> let a = 42 as BigInt
+```
+
+The usual arithmetic operators are provided, as well as conversion to and from a collection of words (of type `UInt`), plus conformances to the obvious usual protocols: `Comparable` (hence also `Equatable`), `Hashable`, `LosslessStringConvertible`, `Codable`, `ExpressibleByIntegerLiteral`, and `SignedInteger` (hence also `Strideable`, `AdditiveArithmetic`, `Numeric`, `SignedNumeric`, and `BinaryInteger`).
+
+### Dependencies:
+- None.
+
+### Test dependencies:
+- `attaswift/BigInt` (reference implementation).
+
+## Design notes
+
+_To be completed_

--- a/Sources/BigIntModule/RandomNumberGenerator.swift
+++ b/Sources/BigIntModule/RandomNumberGenerator.swift
@@ -1,0 +1,31 @@
+extension RandomNumberGenerator {
+  @usableFromInline // @inlinable
+  internal mutating func _next(upperBound: BigInt) -> BigInt {
+    precondition(upperBound > 0, "upperBound must be greater than zero")
+    let bitCount = upperBound.bitWidth &- 1
+    guard bitCount > UInt64.bitWidth else {
+      return BigInt(next(upperBound: UInt64(upperBound)))
+    }
+    
+    let wordCount = (bitCount + (UInt.bitWidth &- 1)) / UInt.bitWidth
+    let mask = (1 as UInt) &<< (bitCount % UInt.bitWidth) &- 1
+    
+    var result: BigInt
+    repeat {
+      var low = next() as UInt
+      var rest = [UInt]()
+      if wordCount > 1 {
+        rest.reserveCapacity(wordCount &- 1)
+        for _ in 1..<(wordCount &- 1) { rest.append(next()) }
+        rest.append(mask == 0 ? next() : next() | mask)
+      } else if mask != 0 {
+        assert(UInt.bitWidth > UInt64.bitWidth)
+        low |= mask
+      }
+      result =
+        BigInt(_combination: 1, significand: BigInt._Significand(low, rest))
+      result._normalize()
+    } while result >= upperBound
+    return result
+  }
+}

--- a/Sources/Numerics/Numerics.swift
+++ b/Sources/Numerics/Numerics.swift
@@ -12,3 +12,4 @@
 // A module that re-exports the complete Swift Numerics public API.
 @_exported import RealModule
 @_exported import ComplexModule
+@_exported import BigIntModule

--- a/Tests/BigIntTests/AttaswiftBigInt.swift
+++ b/Tests/BigIntTests/AttaswiftBigInt.swift
@@ -1,0 +1,3 @@
+import BigInt
+typealias AttaswiftBigInt = BigInt
+typealias AttaswiftBigUInt = BigUInt

--- a/Tests/BigIntTests/BigIntTests.swift
+++ b/Tests/BigIntTests/BigIntTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import BigIntModule
+
+internal func _randomWords(count: Int) -> (BigInt, AttaswiftBigInt) {
+  var words: [UInt] = (0..<Int.random(in: 1..<count)).map { _ in
+    UInt.random(in: 0..<UInt.max)
+  }
+  words.append(0)
+  var temporary
+    = BigInt(_combination: 1, significand: BigInt._Significand(words))
+  temporary._normalize()
+  return (temporary, AttaswiftBigInt(words: words))
+}
+
+final class BigIntModuleTests: XCTestCase {
+  func testLayout() {
+    XCTAssertEqual(MemoryLayout<BigInt>.size, MemoryLayout<Int>.size * 3)
+    XCTAssertEqual(MemoryLayout<BigInt>.stride, MemoryLayout<Int>.size * 3)
+  }
+  
+  func testSignificand() {
+    let x = BigInt._Significand([1, 2, 3])
+    XCTAssertEqual(x._low, 1)
+    XCTAssertEqual(x._rest[0], 2)
+    XCTAssertEqual(x._rest[1], 3)
+  }
+  
+  func testWords() {
+    let i = BigInt(_combination: 1, significand:
+      BigInt._Significand(10284089032038000429, [1319478378503944518]))
+    XCTAssertEqual(i.words.count, 2)
+    XCTAssertEqual(i.words[0], 10284089032038000429)
+    XCTAssertEqual(i.words[1], 1319478378503944518)
+  }
+  
+  func testConversion() {
+    for i in (-42..<42) {
+      let x = BigInt(i)
+      XCTAssertEqual(x._combination, i.signum())
+      XCTAssertEqual(x._significand._low, i.magnitude)
+      XCTAssertEqual(x.description, i.description)
+      let j = Int(x)
+      XCTAssertEqual(i, j)
+    }
+    for _ in 0..<10 {
+      let x = _randomWords(count: 8)
+      XCTAssertEqual(x.0.description, x.1.description)
+      XCTAssertEqual(x.0, BigInt(words: x.1.words))
+      
+      for i in 2...36 {
+        let strings = (String(x.0, radix: i), String(x.1, radix: i))
+        let x = BigInt(strings.0, radix: i)!
+        let y = AttaswiftBigInt(strings.1, radix: i)!
+        XCTAssertEqual(x, BigInt(y), "\(i)")
+      }
+    }
+    for _ in 0..<100 {
+      let x = UInt64.random(in: 0...UInt64.max)
+      let y = Double(bitPattern: x)
+      var temporary = (BigInt(exactly: y), AttaswiftBigInt(exactly: y))
+      if temporary.0 == nil {
+        XCTAssertNil(temporary.1)
+      } else {
+        XCTAssertNotNil(temporary.1)
+        XCTAssertEqual(temporary.0!, BigInt(temporary.1!))
+      }
+      if y.isFinite {
+        XCTAssertEqual(BigInt(y), BigInt(AttaswiftBigInt(y)))
+      }
+      
+      let z = UInt32.random(in: 0...UInt32.max)
+      let w = Float(bitPattern: z)
+      temporary = (BigInt(exactly: w), AttaswiftBigInt(exactly: w))
+      if temporary.0 == nil {
+        XCTAssertNil(temporary.1)
+      } else {
+        XCTAssertNotNil(temporary.1)
+        XCTAssertEqual(temporary.0!, BigInt(temporary.1!))
+      }
+      if w.isFinite {
+        XCTAssertEqual(BigInt(w), BigInt(AttaswiftBigInt(w)))
+      }
+    }
+  }
+  
+  func testAddition() {
+    for _ in 0..<100 {
+      let a = _randomWords(count: 8)
+      let b = _randomWords(count: 8)
+      XCTAssertEqual(a.0 + 0, a.0)
+      XCTAssertEqual(0 + a.0, a.0)
+      XCTAssertEqual(b.0 + 0, b.0)
+      XCTAssertEqual(0 + b.0, b.0)
+      XCTAssertEqual(a.0 - 0, a.0)
+      XCTAssertEqual(0 - a.0, -a.0)
+      XCTAssertEqual(b.0 - 0, b.0)
+      XCTAssertEqual(0 - b.0, -b.0)
+      
+      var results = (a.0 + b.0, a.1 + b.1)
+      let words = (results.0.words, results.1.words)
+      for (left, right) in zip(words.0, words.1) {
+        XCTAssertEqual(left, right, "Expected \(a.1) + \(b.1) == \(results.1)")
+      }
+      results = (a.0 + -b.0, a.1 - b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 + b.0, b.1 - a.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 - b.0, -(a.1 + b.1))
+      XCTAssertEqual(results.0, BigInt(results.1))
+      
+      results = (a.0 - -b.0, a.1 + b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (a.0 - b.0, a.1 - b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 - -b.0, b.1 - a.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 - b.0, -(a.1 + b.1))
+      XCTAssertEqual(results.0, BigInt(results.1))
+    }
+  }
+  
+  func testMultiplication() {
+    let x = (184467440737095516 as BigInt) * 100
+    XCTAssertEqual(x.description, "18446744073709551600")
+    for _ in 0..<100 {
+      let a = _randomWords(count: 8)
+      let b = _randomWords(count: 8)
+      
+      XCTAssertEqual(a.0 * 0, 0)
+      XCTAssertEqual(a.0 * 1, a.0)
+      XCTAssertEqual(0 * a.0, 0)
+      XCTAssertEqual(1 * a.0, a.0)
+      
+      var results = (a.0 * b.0, a.1 * b.1)
+      let words = (results.0.words, results.1.words)
+      for (left, right) in zip(words.0, words.1) {
+        XCTAssertEqual(left, right, "Expected \(a.1) * \(b.1) == \(results.1)")
+      }
+      results = (a.0 * -b.0, a.1 * -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 * b.0, a.1 * -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 * -b.0, a.1 * b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+    }
+    for _ in 0..<10 {
+      let a = _randomWords(count: 64)
+      let b = _randomWords(count: 64)
+      let products = (a.0 * b.0, a.1 * b.1)
+      let words = (products.0.words, products.1.words)
+      for (left, right) in zip(words.0, words.1) {
+        XCTAssertEqual(left, right, "Expected \(a.1) * \(b.1) == \(products.1)")
+      }
+    }
+  }
+  
+  func testBitwiseOperators() {
+    for _ in 0..<100 {
+      let a = _randomWords(count: 8)
+      let b = _randomWords(count: 8)
+      
+      XCTAssertEqual(a.0 & 0, 0)
+      XCTAssertEqual(0 & a.0, 0)
+      XCTAssertEqual(-a.0 & 0, 0)
+      XCTAssertEqual(0 & -a.0, 0)
+      
+      XCTAssertEqual(a.0 | 0, a.0)
+      XCTAssertEqual(0 | a.0, a.0)
+      XCTAssertEqual(-a.0 | 0, -a.0)
+      XCTAssertEqual(0 | -a.0, -a.0)
+      
+      XCTAssertEqual(a.0 ^ 0, a.0)
+      XCTAssertEqual(0 ^ a.0, a.0)
+      XCTAssertEqual(-a.0 ^ 0, -a.0)
+      XCTAssertEqual(0 ^ -a.0, -a.0)
+      
+      var results = (a.0 & b.0, a.1 & b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (a.0 & -b.0, a.1 & -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 & b.0, -a.1 & b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 & -b.0, -a.1 & -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      
+      results = (a.0 | b.0, a.1 | b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (a.0 | -b.0, a.1 | -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 | b.0, -a.1 | b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 | -b.0, -a.1 | -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      
+      results = (a.0 ^ b.0, a.1 ^ b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (a.0 ^ -b.0, a.1 ^ -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 ^ b.0, -a.1 ^ b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+      results = (-a.0 ^ -b.0, -a.1 ^ -b.1)
+      XCTAssertEqual(results.0, BigInt(results.1))
+    }
+    
+    let a = _randomWords(count: 4)
+    XCTAssertEqual((a.0 << 255 + 1) >> 255, a.0)
+    
+    for i in (-100..<100) {
+      XCTAssertEqual(a.0 << i, BigInt(a.1 << i))
+      XCTAssertEqual(a.0 >> i, BigInt(a.1 >> i))
+      //FIXME: There appears to be a bug in attaswift/BigInt (see below).
+      // XCTAssertEqual(-a.0 << i, BigInt(-a.1 << i))
+      // XCTAssertEqual(-a.0 >> i, BigInt(-a.1 >> i))
+      
+      XCTAssertEqual(a.0 >> ((a.0).bitWidth &- 1), 0)
+      XCTAssertEqual(-a.0 >> ((-a.0).bitWidth &- 1), -1)
+    }
+    
+    let b = BigInt(
+      "-1011011100111000101101000110100010111110000110001001111011011",
+      radix: 2)!
+    XCTAssertEqual(b << -51, b >> 51)
+    XCTAssertEqual(b << -51, BigInt("-1011011101", radix: 2)!)
+    //FIXME: This is a concrete example where attaswift/BigInt is incorrect.
+    // XCTAssertEqual(AttaswiftBigInt(b) << -51, AttaswiftBigInt(b << -51))
+    
+    for i in (-100..<100) {
+      XCTAssertEqual(~BigInt(i), BigInt(~i))
+    }
+  }
+  
+  func testTrailingZeroBitCount() {
+    for _ in 0..<100 {
+      let a = _randomWords(count: 8)
+      XCTAssertEqual(a.0.trailingZeroBitCount, a.1.trailingZeroBitCount)
+      XCTAssertEqual((-a.0).trailingZeroBitCount, (-a.1).trailingZeroBitCount)
+      
+      XCTAssertEqual(
+        (a.0 << 12345).trailingZeroBitCount,
+        (a.1 << 12345).trailingZeroBitCount)
+      XCTAssertEqual(
+        (-a.0 << 12345).trailingZeroBitCount,
+        (-a.1 << 12345).trailingZeroBitCount)
+    }
+  }
+}


### PR DESCRIPTION
Here's another stab at implementing a `BigInt` type.

## Implementation

I started with a sign-magnitude representation, then made a few gradual refinements (sadly, the Git history got nuked somewhere in there):

- Taking inspiration from the Java implementation, I switched to storing the _signum_ instead of the _sign_; this allows us to eliminate the two possible representations of zero.

- I decided to include the count of trailing zero words (i.e., an exponent) in a "combination" field, where `_combination = _signum * (_exponent + 1)`. This not only permits constant-time random access of the two's complement representation of negative values, but allows us not to store those trailing zeros. To determine whether a value is a power of two, for instance, it suffices to check whether there is only one nonzero word that has only one nonzero bit.

The resultant representation is somewhat reminiscent of IEEE floating point, with each value decomposed into a signum, exponent, and significand such that notionally `value = _signum * _significand << (UInt.bitWidth * _exponent)`. Overall, it seems to meld the best of both worlds (sign-magnitude and two's complement) for the reasons given above. I don't know of another implementation of `BigInt` that takes this approach, so either it's something new and worthwhile or a very silly diversion.

Taking @lorentey's point that it is best to have some accommodation for storing smaller numbers without allocating an array, I take a slightly different approach here: instead of storing two words in a tuple and any longer values in an array, this implementation unconditionally stores the low word of the significand inline. In this way, serially incrementing or decrementing even most large values should not trigger a copy-on-write operation.

Both schoolbook and Karatsuba multiplication are implemented; currently, the cutoff is at hardcoded at 16 words. Bitwise operators perform as they should (working with the logical two's complement representation—in fact, for simplicity, their implementations make use of efficient constant-time random access to the actual two's complement representation that is provided by `Words`).

Currently, no new APIs that aren't already present on standard library integer types are introduced, other than the initializer `init(words:)` to create a value from a list of `UInt`-typed words.

### To-dos:
[ ] Implement division
[ ] Implement the most salient `BigInt`-specific operations (can be done in a follow-up PR).

## Testing

I have verified that operations currently implemented (all but division, that is) produce the expected results. Not all edge cases are covered yet, however.

So that I can test calculations using randomly generated operands, I use `attaswift/BigInt` as a reference implementation and check that the current implementation produces the same result as does `attaswift/BigInt` (with one exception, where on manual checking it appears that the latter implementation has a bug).

### To-dos:
[ ] Test random number generation APIs
[ ] Compare and optimize performance (can be done in a follow-up PR).
