### PR TITLE
Define `Complex.zeroTangentVectorInitializer`.

### DIFF
--- a/Sources/ComplexModule/Differentiable.swift
+++ b/Sources/ComplexModule/Differentiable.swift
@@ -15,6 +15,11 @@ import _Differentiation
 extension Complex: Differentiable
 where RealType: Differentiable, RealType.TangentVector == RealType {
   public typealias TangentVector = Self
+
+  @inlinable
+  public var zeroTangentVectorInitializer: () -> Self {
+    { Complex.zero }
+  }
 }
 
 extension Complex

--- a/Tests/ComplexTests/DifferentiableTests.swift
+++ b/Tests/ComplexTests/DifferentiableTests.swift
@@ -57,6 +57,10 @@ final class DifferentiableTests: XCTestCase {
     XCTAssertEqual(φDivide(Complex(1, 0)), Complex(0.25, -0.25))
     XCTAssertEqual(φDivide(Complex(0, 1)), Complex(0.25, 0.25))
   }
+
+  func testZeroTangentVectorInitializer() {
+    XCTAssertEqual(Complex<Float>(-5, 5).zeroTangentVector, Complex(0, 0))
+  }
 }
 
 #endif


### PR DESCRIPTION
The `Differentiable.zeroTangentVectorInitializer` protocol requirement is a closure producing a zero tangent vector, capturing minimal information from `self`.
* [Documentation](https://github.com/apple/swift/blob/tensorflow/docs/DifferentiableProgramming.md#the-differentiable-protocol-1)
* [Default synthesis](https://github.com/apple/swift/blob/tensorflow/docs/DifferentiableProgramming.md#default-synthesis)

Fixes the `Complex: Differentiable` conformance for master toolchains:

```console
$ swift --version
Apple Swift version 5.3-dev (LLVM f516ac602c, Swift 09ea5fd1f7)
Target: x86_64-apple-darwin19.3.0

$ swift build
swift-numerics/Sources/ComplexModule/Differentiable.swift:15:1: error: implementation of 'Differentiable' cannot be automatically synthesized in an extension in a different file to the type
extension Complex: Differentiable
^
swift-numerics/Sources/ComplexModule/Complex.swift:48:15: note: type declared here
public struct Complex<RealType> where RealType: Real {
              ^
```

Necessary after https://github.com/apple/swift/pull/31823, which removed the temporary default implementation of `Differentiable.zeroTangentVectorInitializer`.