### PR TITLE
Remove SIMDScalar requirement on numeric type of Quaternion

### DIFF
--- a/Sources/QuaternionModule/Arithmetic.swift
+++ b/Sources/QuaternionModule/Arithmetic.swift
@@ -15,12 +15,12 @@ import RealModule
 extension Quaternion: AdditiveArithmetic {
   @_transparent
   public static func + (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
-    Quaternion(from: lhs.components + rhs.components)
+    Quaternion(real: lhs.w+rhs.w, imaginary: lhs.x+rhs.x, lhs.y+rhs.y, lhs.z+rhs.z)
   }
 
   @_transparent
   public static func - (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
-    Quaternion(from: lhs.components - rhs.components)
+    Quaternion(real: lhs.w-rhs.w, imaginary: lhs.x-rhs.x, lhs.y-rhs.y, lhs.z-rhs.z)
   }
 
   @_transparent
@@ -41,12 +41,12 @@ extension Quaternion: AdditiveArithmetic {
 extension Quaternion {
   @usableFromInline @_transparent
   internal func multiplied(by scalar: RealType) -> Quaternion {
-    Quaternion(from: components * scalar)
+    Quaternion(real: w*scalar, imaginary: x*scalar, y*scalar, z*scalar)
   }
 
   @usableFromInline @_transparent
   internal func divided(by scalar: RealType) -> Quaternion {
-    Quaternion(from: components / scalar)
+    Quaternion(real: w/scalar, imaginary: x/scalar, y/scalar, z/scalar)
   }
 }
 
@@ -54,18 +54,34 @@ extension Quaternion {
 extension Quaternion: AlgebraicField {
   @_transparent
   public static func * (lhs: Quaternion, rhs: Quaternion) -> Quaternion {
+    // The following expressions have been split up so the type-check
+    // can resolve them in a reasonable time.
 
-    let rhsX = SIMD4(+rhs.components.w, +rhs.components.z, -rhs.components.y, +rhs.components.x)
-    let rhsY = SIMD4(-rhs.components.z, +rhs.components.w, +rhs.components.x, +rhs.components.y)
-    let rhsZ = SIMD4(+rhs.components.y, -rhs.components.x, +rhs.components.w, +rhs.components.z)
-    let rhsR = SIMD4(-rhs.components.x, -rhs.components.y, -rhs.components.z, +rhs.components.w)
+    let xW = lhs.w * rhs.x
+    let xX = lhs.x * rhs.w
+    let xY = lhs.y * rhs.z
+    let xZ = lhs.z * rhs.y
+    let x = xW + xX + xY - xZ
 
-    let x = (lhs.components * rhsX).sum()
-    let y = (lhs.components * rhsY).sum()
-    let z = (lhs.components * rhsZ).sum()
-    let r = (lhs.components * rhsR).sum()
+    let yW = lhs.w * rhs.y
+    let yX = lhs.x * rhs.z
+    let yY = lhs.y * rhs.w
+    let yZ = lhs.z * rhs.x
+    let y = yW - yX + yY + yZ
 
-    return Quaternion(from: SIMD4(x,y,z,r))
+    let zW = lhs.w * rhs.z
+    let zX = lhs.x * rhs.y
+    let zY = lhs.y * rhs.x
+    let zZ = lhs.z * rhs.w
+    let z = zW + zX - zY + zZ
+
+    let wW = lhs.w * rhs.w
+    let wX = lhs.x * rhs.x
+    let wY = lhs.y * rhs.y
+    let wZ = lhs.z * rhs.z
+    let w = wW - wX - wY - wZ
+
+    return Quaternion(real: w, imaginary: x, y, z)
   }
 
   @_transparent

--- a/Sources/QuaternionModule/Norms.swift
+++ b/Sources/QuaternionModule/Norms.swift
@@ -29,7 +29,7 @@
 //   a square root.
 //
 // - There exist finite values `q` for which the Euclidean norm is not
-//   representable (consider the quaternion with `r`, `x`, `y` and `z` all
+//   representable (consider the quaternion with `real`, `x`, `y` and `z` all
 //   equal to `RealType.greatestFiniteMagnitude`; the Euclidean norm is
 //   `.sqrt(4) * .greatestFiniteMagnitude`, which overflows).
 //
@@ -38,7 +38,7 @@
 // which makes it the obvious choice to bind `.magnitude`.
 extension Quaternion {
 
-  /// The ∞-norm of the value (`max(abs(r), abs(x), abs(y), abs(z))`).
+  /// The ∞-norm of the value (`max(abs(real), abs(x), abs(y), abs(z))`).
   ///
   /// If you need the Euclidean norm (a.k.a. 2-norm) use the `length` or `lengthSquared`
   /// properties instead.
@@ -56,10 +56,10 @@ extension Quaternion {
   @_transparent
   public var magnitude: RealType {
     guard isFinite else { return .infinity }
-    return max(abs(components.max()), abs(components.min()))
+    return max(abs(x), abs(y), abs(z), abs(w))
   }
 
-  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(r*r + x*x + y*y + z*z)`).
+  /// The Euclidean norm (a.k.a. 2-norm, `sqrt(real*real + x*x + y*y + z*z)`).
   ///
   /// This value is highly prone to overflow or underflow.
   ///
@@ -96,6 +96,13 @@ extension Quaternion {
   /// - `.magnitude`
   @_transparent
   public var lengthSquared: RealType {
-    (components * components).sum()
+    // The following expressions have been split up so the type-check
+    // can resolve them in a reasonable time.
+    
+    let x2 = x*x
+    let y2 = y*y
+    let z2 = z*z
+    let w2 = w*w
+    return x2 + y2 + z2 + w2
   }
 }

--- a/Sources/QuaternionModule/README.md
+++ b/Sources/QuaternionModule/README.md
@@ -4,7 +4,7 @@ This module provides a `Quaternion` type generic over an underlying `RealType`:
 
 ```swift
 1> import QuaternionModule
-2> let q = Quaternion(1, (1,1,1)) // q = 1 + i + j + k
+2> let q = Quaternion(real: 1, imaginary: 1,1,1) // q = 1 + i + j + k
 ```
 
 The usual arithmetic operators are provided for Quaternions, many useful properties, plus conformances to the
@@ -16,12 +16,12 @@ obvious usual protocols: `Equatable`, `Hashable`, `Codable` (if the underlying `
 
 ### The magnitude property
 The `Numeric` protocol requires a `.magnitude` property, but (deliberately) does not fully specify the semantics.
-The most obvious choice for `Quaternion` would be to use the Euclidean norm (aka the "2-norm", given by `sqrt(real*real + i*i + k*k + j*j)`).
+The most obvious choice for `Quaternion` would be to use the Euclidean norm (aka the "2-norm", given by `sqrt(real*real + xi*xi + yk*yk + zj*zj)`).
 However, in practice there are good reasons to use something else instead:
 
 - The 2-norm requires special care to avoid spurious overflow/underflow, but the naive expressions for the 1-norm ("taxicab norm") or ∞-norm ("sup norm") are always correct.
 - Even when care is used, near the overflow boundary the 2-norm and the 1-norm are not representable.
-  As an example, consider `q = Quaternion(big, (big, big, big))`, where `big` is `Double.greatestFiniteMagnitude`. The 1-norm and 2-norm of `q` both overflow (the 1-norm would be `4*big`, and the 2-norm would be `sqrt(4)*big`, neither of which are representable as `Double`), but the ∞-norm is always equal to either `real`, `i`, `j` or `k`, so it is guaranteed to be representable.
+  As an example, consider `q = Quaternion(real: big, imaginary: big, big, big)`, where `big` is `Double.greatestFiniteMagnitude`. The 1-norm and 2-norm of `q` both overflow (the 1-norm would be `4*big`, and the 2-norm would be `sqrt(4)*big`, neither of which are representable as `Double`), but the ∞-norm is always equal to either `real`, `xi`, `yj` or `zk`, so it is guaranteed to be representable.
 Because of this, the ∞-norm is the obvious alternative; it gives the nicest API surface.
 - If we consider the magnitude of more exotic types, like operators, the 1-norm and ∞-norm are significantly easier to compute than the 2-norm (O(n) vs. "no closed form expression, but O(n^3) iterative methods"), so it is nice to establish a precedent of `.magnitude` binding one of these cheaper-to-compute norms.
 - The ∞-norm is heavily used in other computational libraries; for example, it is used by the `izamax` and `icamax` functions in BLAS.

--- a/Tests/QuaternionTests/ArithmeticTests.swift
+++ b/Tests/QuaternionTests/ArithmeticTests.swift
@@ -16,7 +16,7 @@ import RealModule
 
 final class ArithmeticTests: XCTestCase {
 
-  func testMultiplication<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testMultiplication<T: Real>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
       let q = Quaternion<T>(real: value, imaginary: value, value, value)
       XCTAssertEqual(q * .one, q)
@@ -28,9 +28,12 @@ final class ArithmeticTests: XCTestCase {
   func testMultiplication() {
     testMultiplication(Float32.self)
     testMultiplication(Float64.self)
+    #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+    testMultiplication(Float80.self)
+    #endif
   }
 
-  func testDivision<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testDivision<T: Real>(_ type: T.Type) {
     for value: T in [-3, -2, -1, +1, +2, +3] {
       let q = Quaternion<T>(real: value, imaginary: value, value, value)
       XCTAssertEqual(q/q, .one)
@@ -49,9 +52,12 @@ final class ArithmeticTests: XCTestCase {
   func testDivision() {
     testDivision(Float32.self)
     testDivision(Float64.self)
+    #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+    testDivision(Float80.self)
+    #endif
   }
 
-  func testDivisionByZero<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testDivisionByZero<T: Real>(_ type: T.Type) {
     XCTAssertFalse((Quaternion<T>(real: 0, imaginary: 0, 0, 0) / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
     XCTAssertFalse((Quaternion<T>(real: 1, imaginary: 1, 1, 1) / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
     XCTAssertFalse((Quaternion<T>.infinity / Quaternion<T>(real: 0, imaginary: 0, 0, 0)).isFinite)
@@ -63,5 +69,8 @@ final class ArithmeticTests: XCTestCase {
   func testDivisionByZero() {
     testDivisionByZero(Float32.self)
     testDivisionByZero(Float64.self)
+    #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+    testDivisionByZero(Float80.self)
+    #endif
   }
 }

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -16,7 +16,7 @@ import RealModule
 
 final class PropertyTests: XCTestCase {
 
-  func testProperties<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testProperties<T: Real>(_ type: T.Type) {
     // The real and imaginary parts of a non-finite value should be nan.
     XCTAssertTrue(Quaternion<T>.infinity.real.isNaN)
     XCTAssertTrue(Quaternion<T>.infinity.imaginary.x.isNaN)
@@ -32,16 +32,19 @@ final class PropertyTests: XCTestCase {
     XCTAssertEqual(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).length, .infinity)
     // The length of a zero value should be zero.
     XCTAssertEqual(Quaternion<T>.zero.length, .zero)
-    XCTAssertEqual(Quaternion<T>(.zero, -.zero).length, .zero)
-    XCTAssertEqual(Quaternion<T>(-.zero, -.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(real:  .zero, imaginary: -.zero, -.zero, -.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(real: -.zero, imaginary: -.zero, -.zero, -.zero).length, .zero)
   }
 
   func testProperties() {
     testProperties(Float32.self)
     testProperties(Float64.self)
+    #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+    testProperties(Float80.self)
+    #endif
   }
 
-  func testEquatableHashable<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testEquatableHashable<T: Real>(_ type: T.Type) {
     // Validate that all zeros compare and hash equal, and all non-finites
     // do too.
     let zeros = [
@@ -105,9 +108,12 @@ final class PropertyTests: XCTestCase {
   func testEquatableHashable() {
     testEquatableHashable(Float32.self)
     testEquatableHashable(Float64.self)
+    #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+    testEquatableHashable(Float80.self)
+    #endif
   }
 
-  func testCodable<T: Real & SIMDScalar>(_ type: T.Type) throws {
+  func testCodable<T: Real & Codable>(_ type: T.Type) throws {
     let encoder = JSONEncoder()
     encoder.nonConformingFloatEncodingStrategy = .convertToString(
       positiveInfinity: "inf",
@@ -132,5 +138,6 @@ final class PropertyTests: XCTestCase {
   func testCodable() throws {
     try testCodable(Float32.self)
     try testCodable(Float64.self)
+    // Float80 doesn't conform to Codable.
   }
 }


### PR DESCRIPTION
This PR removes the SIMD storage on quaternions, replacing it with `(x,y,z,w)` properties and in-turn lifts the requirement of SIMDScalar conformance on the numeric type.

During the discussion on the initial sketch PR it has been brought up that is maybe worth dropping the SIMD storage and the requirement of the SIMDScalar on Quaternion and this PR should help to find the benefits and disadvantages on the API.