### PR TITLE
Approximate equality comparisons.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     .target(name: "_NumericsShims", dependencies: []),
     .target(name: "RealModule", dependencies: ["_NumericsShims"]),
     
-    .testTarget(name: "ComplexTests", dependencies: ["ComplexModule", "_NumericsShims"]),
+    .testTarget(name: "ComplexTests", dependencies: ["Numerics"]),
     .testTarget(name: "RealTests", dependencies: ["RealModule"]),
   ]
 )

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -67,7 +67,7 @@ extension Numeric where Magnitude: FloatingPoint {
     )
   }
   
-  /// Compares `self` and `other` for approximate equality with a specified tolerances.
+  /// Compares `self` and `other` for approximate equality with specified tolerances.
   ///
   /// `true` if `self` and `other` are equal, or if they are finite and either
   /// ```

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -10,16 +10,15 @@
 //===----------------------------------------------------------------------===//
 
 extension Numeric where Magnitude: FloatingPoint {
-  /// Compares `self` and `other` for approximate equality with a specified
-  /// relative tolerance and implicit absolute tolerance.
+  /// Test if `self` and `other` are approximately equal.
   ///
   /// `true` if `self` and `other` are equal, or if they are finite and
   /// ```
-  /// (self - other).magnitude ≤ relativeTolerance * scale
+  /// norm(self - other) <= relativeTolerance * scale
   /// ```
   /// where `scale` is
   /// ```
-  /// max(self.magnitude, other.magnitude, .leastNormalMagnitude)
+  /// max(norm(self), norm(other), .leastNormalMagnitude)
   /// ```
   ///
   /// The default value of `relativeTolerance` is `.ulpOfOne.squareRoot()`,
@@ -28,22 +27,27 @@ extension Numeric where Magnitude: FloatingPoint {
   /// computation being performed, but is not suitable for all use cases.
   ///
   /// Mathematical Properties:
-  /// -
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _reflexive_ for
+  /// ------------------------
+  /// 
+  /// - `isApproximatelyEqual(to:relativeTolerance:norm:)` is _reflexive_ for
   ///   non-exceptional values (such as NaN).
   ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _symmetric_.
+  /// - `isApproximatelyEqual(to:relativeTolerance:norm:)` is _symmetric_.
   ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is __not__ _transitive_.
+  /// - `isApproximatelyEqual(to:relativeTolerance:norm:)` is __not__ _transitive_.
   ///   Because of this, approximately equality is __not an equivalence relation__,
   ///   even when restricted to non-exceptional values.
   ///
   /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
   ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
   ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _scale invariant_,
+  /// - `isApproximatelyEqual(to:relativeTolerance:norm:)` is _scale invariant_,
   ///   so long as no underflow or overflow has occured, and no exceptional value is produced
   ///   by the scaling.
+  ///
+  /// See Also:
+  /// -------
+  /// - `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:norm:])`
   ///
   /// - Parameters:
   ///
@@ -55,32 +59,40 @@ extension Numeric where Magnitude: FloatingPoint {
   ///     This value should be non-negative and less than or equal to 1.
   ///     This constraint on is only checked in debug builds, because a mathematically
   ///     well-defined result exists for any tolerance, even one out of range.
+  ///
+  ///   - norm: The [norm] to use for the comparison.
+  ///     Defaults to `\.magnitude`.
+  ///
+  /// [norm]: https://en.wikipedia.org/wiki/Norm_(mathematics)
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
-    relativeTolerance: Magnitude = Magnitude.ulpOfOne.squareRoot()
+    relativeTolerance: Magnitude = Magnitude.ulpOfOne.squareRoot(),
+    norm: (Self) -> Magnitude = \.magnitude
   ) -> Bool {
     return isApproximatelyEqual(
       to: other,
       absoluteTolerance: relativeTolerance * Magnitude.leastNormalMagnitude,
-      relativeTolerance: relativeTolerance
+      relativeTolerance: relativeTolerance,
+      norm: norm
     )
   }
   
-  /// Compares `self` and `other` for approximate equality with specified tolerances.
+  /// Test if `self` and `other` are approximately equal with specified tolerances.
   ///
   /// `true` if `self` and `other` are equal, or if they are finite and either
   /// ```
-  /// (self - other).magnitude ≤ absoluteTolerance
+  /// (self - other).magnitude <= absoluteTolerance
   /// ```
   /// or
   /// ```
-  /// (self - other).magnitude ≤ relativeTolerance * scale
+  /// (self - other).magnitude <= relativeTolerance * scale
   /// ```
   /// where `scale` is `max(self.magnitude, other.magnitude)`.
   ///
   /// Mathematical Properties:
-  /// -
+  /// ------------------------
+  ///
   /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:)`
   ///   is _reflexive_ for non-exceptional values (such as NaN).
   ///
@@ -94,6 +106,76 @@ extension Numeric where Magnitude: FloatingPoint {
   /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
   ///   (Under the assumption that `norm` implements a valid norm, which cannot be checked
   ///   by this function.)
+  ///
+  /// See Also:
+  /// -------
+  /// - `isApproximatelyEqual(to:[relativeTolerance:])`
+  ///
+  /// - Parameters:
+  ///
+  ///   - other: The value to which `self` is compared.
+  ///
+  ///   - absoluteTolerance: The absolute tolerance to use in the comparison.
+  ///
+  ///     This value should be non-negative and finite.
+  ///     This constraint on is only checked in debug builds, because a mathematically
+  ///     well-defined result exists for any tolerance, even one out of range.
+  ///
+  ///   - relativeTolerance: The relative tolerance to use in the comparison.
+  ///     Defaults to zero.
+  ///
+  ///     This value should be non-negative and less than or equal to 1.
+  ///     This constraint on is only checked in debug builds, because a mathematically
+  ///     well-defined result exists for any tolerance, even one out of range.
+  @inlinable @inline(__always)
+  public func isApproximatelyEqual(
+    to other: Self,
+    absoluteTolerance: Magnitude,
+    relativeTolerance: Magnitude = 0
+  ) -> Bool {
+    self.isApproximatelyEqual(
+      to: other,
+      absoluteTolerance: absoluteTolerance,
+      relativeTolerance: relativeTolerance,
+      norm: \.magnitude
+    )
+  }
+}
+
+extension AdditiveArithmetic {
+  /// Test if `self` and `other` are approximately equal with specified tolerances and norm.
+  ///
+  /// `true` if `self` and `other` are equal, or if they are finite and either
+  /// ```
+  /// norm(self - other) <= absoluteTolerance
+  /// ```
+  /// or
+  /// ```
+  /// norm(self - other) <= relativeTolerance * scale
+  /// ```
+  /// where `scale` is `max(norm(self), norm(other))`.
+  ///
+  /// Mathematical Properties:
+  /// ------------------------
+  ///
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:norm:)`
+  ///   is _reflexive_ for non-exceptional values (such as NaN).
+  ///
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:norm:)`
+  ///   is _symmetric_.
+  ///
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:norm:)`
+  ///   is __not__ _transitive_. Because of this, approximately equality is
+  ///   __not an equivalence relation__, even when restricted to non-exceptional values.
+  ///
+  /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
+  ///   (Under the assumption that `norm` implements a valid norm, which cannot be checked
+  ///   by this function.)
+  ///
+  /// See Also:
+  /// -------
+  /// - `isApproximatelyEqual(to:[relativeTolerance:norm:])`
+  /// - `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:])`
   ///
   /// - Parameters:
   ///
@@ -112,13 +194,11 @@ extension Numeric where Magnitude: FloatingPoint {
   ///     This constraint on is only checked in debug builds, because a mathematically
   ///     well-defined result exists for any tolerance, even one out of range.
   ///
-  ///   - norm: The norm to use for the comparison. Defaults to the `.magnitude`
-  ///     property.
+  ///   - norm: The norm to use for the comparison.
+  ///     Defaults to `\.magnitude`.
   ///
-  ///     When porting code or working with specialized algorithms, it may
-  ///     be desirable to override the norm. For example, if we wanted to test if
-  ///     a complex value was inside a circle of radius 0.001 centered at (1 + 0i), we
-  ///     could use:
+  ///     For example, if we wanted to test if a complex value was inside a circle of
+  ///     radius 0.001 centered at (1 + 0i), we could use:
   ///     ```
   ///     z.isApproximatelyEqual(
   ///       to: 1,
@@ -128,13 +208,20 @@ extension Numeric where Magnitude: FloatingPoint {
   ///     ```
   ///     (if we used the default, we would be testing if `z` were inside a square region
   ///     instead.)
-  @inlinable @inline(__always)
-  public func isApproximatelyEqual(
+  @inlinable
+  public func isApproximatelyEqual<Magnitude>(
     to other: Self,
     absoluteTolerance: Magnitude,
     relativeTolerance: Magnitude = 0,
-    norm: (Self) -> Magnitude = { $0.magnitude }
-  ) -> Bool {
+    norm: (Self) -> Magnitude
+  ) -> Bool
+  // TODO: constraint should really be weaker than FloatingPoint,
+  // but we need to have `isFinite` for it to work correctly with
+  // floating-point magnitudes in generic contexts, which is the
+  // most common case. The fix for this is to lift the isFinite
+  // requirement to Numeric in the standard library, but that's
+  // source-breaking, so requires an ABI rumspringa.
+  where Magnitude: FloatingPoint {
     assert(
       absoluteTolerance >= 0 && absoluteTolerance.isFinite,
       "absoluteTolerance should be non-negative and finite, " +

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -9,103 +9,130 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A tolerance to use for approximate comparisons
-///
-/// These values are consumed by the `approximatelyEquals` method defined on `Numeric`
-/// whenever the `Magnitude` associated type conforms to floating-point.
-public enum Tolerance<T: FloatingPoint> {
-  case relative(_ tolerance: T = T.ulpOfOne.squareRoot(), minimumScale: T = .leastNormalMagnitude)
-  case absolute(_ tolerance: T)
-}
-
 extension Numeric where Magnitude: FloatingPoint {
-  /// Approximate equality comparison
+  /// Compares `self` and `other` for approximate equality with default
+  /// tolerances.
+  ///
+  /// `a.isApproximatelyEqual(to: b)` is `true` if `a` and `b`
+  /// are equal, or if both are finite and `|a - b| ≤ √u * max(|a|,|b|,n)`,
+  /// where `||` is the norm computed by the `.magnitude` property,
+  /// `u` is `.ulpOfOne`, and `n` is `.leastNormalMagnitude`.
   ///
   /// Due to rounding of intermediate results, "the same" value computed using
   /// two different techniques frequently has slightly different results in
   /// floating-point arithmetic. This comparison method may be helpful in
   /// these situations.
   ///
-  /// The simplest use of this method looks like:
   /// ```
-  /// a.approximatelyEquals(b)
+  /// a.isApproximatelyEqual(to: b)
   /// ```
-  /// when used like this, the result is true if `a ` and `b` agree to about
-  /// half the representable significant digits, which is the usual naive
-  /// guidance in numerical analysis ("if you don't have a careful analysis,
-  /// half your bits are probably bad").
+  /// is true if `a ` and `b` agree to about half the representable
+  /// significant digits, which is the usual naive guidance in numerical
+  /// analysis ("if you don't have a careful analysis, half your bits
+  /// are probably bad").
   ///
-  /// You can specify a tolerance to use for more specialized scenarios.
-  /// Three types of tolerance are supported:
-  ///
-  /// - `.absolute(t)`
-  ///   `a` is approximately equal to `b` with absolute tolerance `t` if
-  ///   ```
-  ///   (a - b).magnitude < t
-  ///   ```
-  ///   The trouble with an absolute tolerance is that it only makes sense
-  ///   when you know the expected scale of the `a` and `b`, but the *raison d'être*
-  ///   of floating-point numbers is to avoid scale dependent computations as much
-  ///   as possible. Because of this absolute tolerances are often a bad choice,
-  ///   unless you have very specific requirements.
-  ///
-  ///   There is no default absolute tolerance, because it's impossible for a general-purpose
-  ///   library to know what the scale of the values being compared might be.
-  ///
-  ///   However, when you do know the scale of an expected result, this can be an excellent
-  ///   choice. For example, suppose we want to repeat an iterative process until the result
-  ///   is within `0.1` of π:
-  ///   ```
-  ///   while !result.approximatelyEquals(.pi, tolerance: .absolute(0.1)) {
-  ///   }
-  ///   ```
-  ///   The tolerance `t` must be positive and finite.
-  ///
-  /// - `.relative(t)`
-  ///   `a` and `b` are approximately equal with relative tolerance `t` if
-  ///   ```
-  ///   let scale = max(a.magnitude, b.magnitude, .leastNormalMagnitude)
-  ///   return (a - b).magnitude < t * scale
-  ///   ```
-  ///   This type of tolerance matches well with the scale invariance of floating-point,
-  ///   making it a good choice for most problems. If you do not specify a tolerance,
-  ///   `approximatelyEquals` uses a relative tolerance of `sqrt(ulpOfOne)`.
-  ///
-  ///   The tolerance `t` must be in `.ulpOfOne ..< 1`.
-  ///
-  /// - `.relative(t, minimumScale: s)`
-  ///   In some cases it is desirable to override the `minimumScale` used in a relative
-  ///   comparison (either by setting it to zero, so that there is no rolloff at zero, or by setting it
-  ///   to a much larger value to account for cancellation). When a `minimumScale` is
-  ///   specified, the computation performed is:
-  ///   ```
-  ///   let scale = max(a.magnitude, b.magnitude, minimumScale)
-  ///   return (a - b).magnitude < t * scale
-  ///   ```
-  ///   The tolerance `t` must be in `.ulpOfOne ..< 1`.  The `minimumScale` must
-  ///   be non-negative and finite.
-  ///
-  /// - Parameters:
-  ///   - other: The value to compare.
-  ///   - tolerance: Either `.relative(...)` or `.absolute(t)`.
-  @inlinable
-  public func approximatelyEquals(
-    _ other: Self,
-    tolerance: Tolerance<Magnitude> = .relative()
+  /// More precisely, the call shown above is exactly equivalent to:
+  /// ```
+  /// let rtol = Magnitude.ulpOfOne.squareRoot()
+  /// a.isApproximatelyEqual(to: b, relativeTolerance: rtol)
+  /// ```
+  /// or:
+  /// ```
+  /// let rtol = Magnitude.ulpOfOne.squareRoot()
+  /// let atol = Magnitude.leastNormalMagnitude * rtol
+  /// a.isApproximatelyEqual(to: b,
+  ///   relativeTolerance: rtol,
+  ///   absoluteTolerance: atol
+  /// )
+  /// ```
+  /// Consult the documentation for those methods for a detailed
+  /// description of how the comparison is performed, and how to
+  /// choose tolerances for your particular situation.
+  @inlinable @inline(__always)
+  public func isApproximatelyEqual(
+    to other: Self
   ) -> Bool {
-    // If a and b are actually equal, then they are certainly *almost* equal,
-    // with any allowable tolerance.
+    return isApproximatelyEqual(
+      to: other,
+      relativeTolerance: Magnitude.ulpOfOne.squareRoot()
+    )
+  }
+  
+  /// Compares `self` and `other` for approximate equality with a specified
+  /// relative tolerance and implicit absolute tolerance.
+  ///
+  /// If we ignore underflow and overflow for the moment, floating-point arithmetic
+  /// is scale-invariant. Because of this, a _relative_ comparison usually
+  /// makes the most sense when defining approximate equality.
+  ///
+  /// Normally in mathematics, comparison for relative approximate equality looks like:
+  /// ```
+  /// |a - b| ≤ tolerance * max(|a|,|b|)
+  /// ```
+  /// where `|a|` is the magnitude of `a` measured by some _norm_.
+  ///
+  /// However, floating-point is not perfectly scale-invariant when underflow occurs,
+  /// so we slightly modify the definition of relative comparison to account for this,
+  /// and use the following instead:
+  /// ```
+  /// |a - b| ≤ tolerance * max(|a|,|b|,n)
+  /// ```
+  /// where `n` is `.leastNormalMagnitude`, or equivalently:
+  /// ```
+  /// |a - b| ≤ max(tolerance*n, tolerance*max(|a|,|b|))
+  /// ```
+  /// This means that the actual error allowed for all subnormal values is exactly
+  /// the tolerance allowed for the smallest normal value. If you want to avoid this
+  /// special handling for subnormal values, pass an explicit
+  /// `absoluteTolerance: 0` parameter.
+  ///
+  /// Scale-invariance also breaks down when overflow occurs, but in that case no
+  /// useful comparison is recoverable, so we simply do not try; infinity compares
+  /// not equal to any finite value with any allowed tolerance.
+  @inlinable @inline(__always)
+  public func isApproximatelyEqual(
+    to other: Self,
+    relativeTolerance: Magnitude
+  ) -> Bool {
+    return isApproximatelyEqual(
+      to: other,
+      relativeTolerance: relativeTolerance,
+      absoluteTolerance: relativeTolerance * Magnitude.leastNormalMagnitude
+    )
+  }
+  
+  /// Compares `self` and `other` for approximate equality with a specified tolerances.
+  ///
+  /// `a.isApproximatelyEqual(to: b, relativeTolerance: rtol, absoluteTolerance: atol)`
+  /// is `true` if a and b are equal, or if they are finite and
+  /// ```
+  /// |a - b| ≤ max(atol, rtol * max(|a|,|b|))
+  /// ```
+  ///
+  /// Note that if `relativeTolerance` is omitted or is zero, a pure absolute tolerance is used:
+  /// ```
+  /// |a - b| ≤ atol
+  /// ```
+  ///
+  /// If `absoluteTolerance` is zero, a pure relative tolerance is used:
+  /// ```
+  /// |a - b| ≤ rtol * max(|a|,|b|)
+  /// ```
+  ///
+  /// Note that if `absoluteTolerance` is _omitted_,
+  /// `relativeTolerance * .leastNormalMagnitude` is used, _not zero_.
+  @inlinable
+  public func isApproximatelyEqual(
+    to other: Self,
+    relativeTolerance: Magnitude = 0,
+    absoluteTolerance: Magnitude
+  ) -> Bool {
+    assert(absoluteTolerance >= 0 && absoluteTolerance.isFinite)
+    assert(relativeTolerance >= 0 && relativeTolerance <= 1)
     if self == other { return true }
     let delta = (self - other).magnitude
-    switch tolerance {
-    case let .absolute(atol):
-      assert(atol > 0 && atol.isFinite, "Absolute tolerance must be positive and finite.")
-      return delta < atol
-    case let .relative(rtol, floor):
-      assert(rtol >= .ulpOfOne && rtol < 1, "Relative tolerance must be in [.ulpOfOne, 1).")
-      assert(floor >= 0 && floor.isFinite, "Minimum scale must be non-negative and finite.")
-      let scale = max(self.magnitude, other.magnitude, floor)
-      return delta < scale*rtol
-    }
+    let scale = max(self.magnitude, other.magnitude)
+    let bound = max(absoluteTolerance, scale*relativeTolerance)
+    return delta.isFinite && delta <= bound
   }
 }

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -46,12 +46,15 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   by the scaling.
   ///
   /// - Parameters:
+  ///
   ///   - other: The value to which `self` is compared.
+  ///
   ///   - relativeTolerance: The tolerance to use for the comparison.
-  ///   If no tolerance is provided, `.ulpOfOne.squareRoot()` is used.
-  ///   This value should be non-negative and less than or equal to 1.
-  ///   This constraint on is only checked in debug builds, because a mathematically
-  ///   well-defined result exists for any tolerance, even one out of range.
+  ///     Defaults to `.ulpOfOne.squareRoot()`.
+  ///
+  ///     This value should be non-negative and less than or equal to 1.
+  ///     This constraint on is only checked in debug builds, because a mathematically
+  ///     well-defined result exists for any tolerance, even one out of range.
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
@@ -93,24 +96,44 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   by this function.)
   ///
   /// - Parameters:
+  ///
   ///   - other: The value to which `self` is compared.
+  ///
   ///   - absoluteTolerance: The absolute tolerance to use in the comparison.
-  ///   This value should be non-negative and finite.
-  ///   This constraint on is only checked in debug builds, because a mathematically
-  ///   well-defined result exists for any tolerance, even one out of range.
+  ///
+  ///     This value should be non-negative and finite.
+  ///     This constraint on is only checked in debug builds, because a mathematically
+  ///     well-defined result exists for any tolerance, even one out of range.
+  ///
   ///   - relativeTolerance: The relative tolerance to use in the comparison.
-  ///   If no relativeTolerance is provided, zero is used.
-  ///   This value should be non-negative and less than or equal to 1.
-  ///   This constraint on is only checked in debug builds, because a mathematically
-  ///   well-defined result exists for any tolerance, even one out of range.
-  ///   - norm: Allows you to specify what norm to use. Defaults to using the
-  ///   `.magnitude` property.
+  ///     Defaults to zero.
+  ///
+  ///     This value should be non-negative and less than or equal to 1.
+  ///     This constraint on is only checked in debug builds, because a mathematically
+  ///     well-defined result exists for any tolerance, even one out of range.
+  ///
+  ///   - norm: The norm to use for the comparison. Defaults to the `.magnitude`
+  ///     property.
+  ///
+  ///     When porting code or working with specialized algorithms, it may
+  ///     be desirable to override the norm. For example, if we wanted to test if
+  ///     a complex value was inside a circle of radius 0.001 centered at (1 + 0i), we
+  ///     could use:
+  ///     ```
+  ///     z.isApproximatelyEqual(
+  ///       to: 1,
+  ///       absoluteTolerance: 0.001,
+  ///       norm: \.length
+  ///     )
+  ///     ```
+  ///     (if we used the default, we would be testing if `z` were inside a square region
+  ///     instead.)
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
     absoluteTolerance: Magnitude,
     relativeTolerance: Magnitude = 0,
-    norm: (Self) -> Magnitude = \.magnitude
+    norm: (Self) -> Magnitude = { $0.magnitude }
   ) -> Bool {
     assert(
       absoluteTolerance >= 0 && absoluteTolerance.isFinite,

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -110,7 +110,7 @@ extension Numeric where Magnitude: FloatingPoint {
     to other: Self,
     absoluteTolerance: Magnitude,
     relativeTolerance: Magnitude = 0,
-    norm: (Self) -> Magnitude = { $0.magnitude }
+    norm: (Self) -> Magnitude = \.magnitude
   ) -> Bool {
     assert(
       absoluteTolerance >= 0 && absoluteTolerance.isFinite,

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -137,12 +137,12 @@ extension Numeric where Magnitude: FloatingPoint {
   ) -> Bool {
     assert(
       absoluteTolerance >= 0 && absoluteTolerance.isFinite,
-      "absoluteTolerance should be non-negative and finite," +
+      "absoluteTolerance should be non-negative and finite, " +
       "but is \(absoluteTolerance)."
     )
     assert(
       relativeTolerance >= 0 && relativeTolerance <= 1,
-      "relativeTolerance should be non-negative and <= 1," +
+      "relativeTolerance should be non-negative and <= 1, " +
       "but is \(relativeTolerance)."
     )
     if self == other { return true }

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -203,8 +203,16 @@ extension Numeric where Magnitude: FloatingPoint {
     relativeTolerance: Magnitude = 0,
     absoluteTolerance: Magnitude
   ) -> Bool {
-    assert(absoluteTolerance >= 0 && absoluteTolerance.isFinite)
-    assert(relativeTolerance >= 0 && relativeTolerance <= 1)
+    assert(
+      absoluteTolerance >= 0 && absoluteTolerance.isFinite,
+      "absoluteTolerance should be non-negative and finite," +
+      "but is \(absoluteTolerance)."
+    )
+    assert(
+      relativeTolerance >= 0 && relativeTolerance <= 1,
+      "relativeTolerance should be non-negative and <= 1," +
+      "but is \(relativeTolerance)."
+    )
     if self == other { return true }
     let delta = (self - other).magnitude
     let scale = max(self.magnitude, other.magnitude)

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -15,18 +15,79 @@
 /// whenever the `Magnitude` associated type conforms to floating-point.
 public enum Tolerance<T: FloatingPoint> {
   case relative(_ tolerance: T = T.ulpOfOne.squareRoot(), minimumScale: T = .leastNormalMagnitude)
-  case absolute(_ tolerance: T = T.ulpOfOne.squareRoot())
+  case absolute(_ tolerance: T)
 }
 
 extension Numeric where Magnitude: FloatingPoint {
   /// Approximate equality comparison
   ///
-  /// Due to rounding of intermediate results, "the same" value computed using two different techniques
-  /// frequently has a slightly different result in floating-point arithmetic. This comparison method may
-  /// be helpful in these situations.
+  /// Due to rounding of intermediate results, "the same" value computed using
+  /// two different techniques frequently has slightly different results in
+  /// floating-point arithmetic. This comparison method may be helpful in
+  /// these situations.
   ///
-  /// By default, this method performs a relative comparison with a minimum scale set to the underflow
-  /// threshold and a tolerance of √ulpOfOne. This is as sensible a default as any.
+  /// The simplest use of this method looks like:
+  /// ```
+  /// a.approximatelyEquals(b)
+  /// ```
+  /// when used like this, the result is true if `a ` and `b` agree to about
+  /// half the representable significant digits, which is the usual naive
+  /// guidance in numerical analysis ("if you don't have a careful analysis,
+  /// half your bits are probably bad").
+  ///
+  /// You can specify a tolerance to use for more specialized scenarios.
+  /// Three types of tolerance are supported:
+  ///
+  /// - `.absolute(t)`
+  ///   `a` is approximately equal to `b` with absolute tolerance `t` if
+  ///   ```
+  ///   (a - b).magnitude < t
+  ///   ```
+  ///   The trouble with an absolute tolerance is that it only makes sense
+  ///   when you know the expected scale of the `a` and `b`, but the *raison d'être*
+  ///   of floating-point numbers is to avoid scale dependent computations as much
+  ///   as possible. Because of this absolute tolerances are often a bad choice,
+  ///   unless you have very specific requirements.
+  ///
+  ///   There is no default absolute tolerance, because it's impossible for a general-purpose
+  ///   library to know what the scale of the values being compared might be.
+  ///
+  ///   However, when you do know the scale of an expected result, this can be an excellent
+  ///   choice. For example, suppose we want to repeat an iterative process until the result
+  ///   is within `0.1` of π:
+  ///   ```
+  ///   while !result.approximatelyEquals(.pi, tolerance: .absolute(0.1)) {
+  ///   }
+  ///   ```
+  ///   The tolerance `t` must be positive and finite.
+  ///
+  /// - `.relative(t)`
+  ///   `a` and `b` are approximately equal with relative tolerance `t` if
+  ///   ```
+  ///   let scale = max(a.magnitude, b.magnitude, .leastNormalMagnitude)
+  ///   return (a - b).magnitude < t * scale
+  ///   ```
+  ///   This type of tolerance matches well with the scale invariance of floating-point,
+  ///   making it a good choice for most problems. If you do not specify a tolerance,
+  ///   `approximatelyEquals` uses a relative tolerance of `sqrt(ulpOfOne)`.
+  ///
+  ///   The tolerance `t` must be in `.ulpOfOne ..< 1`.
+  ///
+  /// - `.relative(t, minimumScale: s)`
+  ///   In some cases it is desirable to override the `minimumScale` used in a relative
+  ///   comparison (either by setting it to zero, so that there is no rolloff at zero, or by setting it
+  ///   to a much larger value to account for cancellation). When a `minimumScale` is
+  ///   specified, the computation performed is:
+  ///   ```
+  ///   let scale = max(a.magnitude, b.magnitude, minimumScale)
+  ///   return (a - b).magnitude < t * scale
+  ///   ```
+  ///   The tolerance `t` must be in `.ulpOfOne ..< 1`.  The `minimumScale` must
+  ///   be positive and finite.
+  ///
+  /// - Parameters:
+  ///   - other: The value to compare.
+  ///   - tolerance: Either `.relative(...)` or `.absolute(t)`.
   @inlinable
   public func approximatelyEquals(
     _ other: Self,

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -48,6 +48,28 @@ extension Numeric where Magnitude: FloatingPoint {
   /// Consult the documentation for those methods for a detailed
   /// description of how the comparison is performed, and how to
   /// choose tolerances for your particular situation.
+  ///
+  /// Mathematical Properties:
+  /// -
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _reflexive_ for
+  ///   non-exceptional values (such as NaN).
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _symmetric_.
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is __not__ _transitive_.
+  ///   Because of this, approximately equality is __not an equivalence relation__,
+  ///   even when restricted to non-exceptional values.
+  ///
+  /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
+  ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _scale invariant_,
+  ///   so long as no underflow or overflow occurs, and no exceptional value is produced
+  ///   by the scaling.
+  ///
+  /// - Parameters:
+  ///   - other: The value to which `self` is compared.
+  ///
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self
@@ -89,6 +111,31 @@ extension Numeric where Magnitude: FloatingPoint {
   /// Scale-invariance also breaks down when overflow occurs, but in that case no
   /// useful comparison is recoverable, so we simply do not try; infinity compares
   /// not equal to any finite value with any allowed tolerance.
+  ///
+  /// Mathematical Properties:
+  /// -
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _reflexive_ for
+  ///   non-exceptional values (such as NaN).
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _symmetric_.
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is __not__ _transitive_.
+  ///   Because of this, approximately equality is __not an equivalence relation__,
+  ///   even when restricted to non-exceptional values.
+  ///
+  /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
+  ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _scale invariant_,
+  ///   so long as no underflow or overflow occurs, and no exceptional value is produced
+  ///   by the scaling.
+  ///
+  /// - Parameters:
+  ///   - other: The value to which `self` is compared.
+  ///   - relativeTolerance: The tolerance to use for the comparison.
+  ///   This value should be non-negative and less than or equal to 1.
+  ///   This constraint on is only checked in debug builds, because a mathematically
+  ///   well-defined result exists for any tolerance, even one out of range.
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
@@ -108,8 +155,13 @@ extension Numeric where Magnitude: FloatingPoint {
   /// ```
   /// |a - b| ≤ max(atol, rtol * max(|a|,|b|))
   /// ```
+  /// This is equivalent to saying that the comparison satisfies _either_ the absolute tolerance,
+  /// _or_ the relative tolerance; it need not satisfy both:
+  /// ```
+  /// |a - b| ≤ atol OR |a - b| ≤ rtol * max(|a|,|b|)
+  /// ```
   ///
-  /// Note that if `relativeTolerance` is omitted or is zero, a pure absolute tolerance is used:
+  /// If `relativeTolerance` is omitted or is zero, a pure absolute tolerance is used:
   /// ```
   /// |a - b| ≤ atol
   /// ```
@@ -119,8 +171,32 @@ extension Numeric where Magnitude: FloatingPoint {
   /// |a - b| ≤ rtol * max(|a|,|b|)
   /// ```
   ///
-  /// Note that if `absoluteTolerance` is _omitted_,
-  /// `relativeTolerance * .leastNormalMagnitude` is used, _not zero_.
+  /// Mathematical Properties:
+  /// -
+  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  ///   is _reflexive_ for non-exceptional values (such as NaN).
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  ///   is _symmetric_.
+  ///
+  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  ///   is __not__ _transitive_. Because of this, approximately equality is
+  ///   __not an equivalence relation__, even when restricted to non-exceptional values.
+  ///
+  /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
+  ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
+  ///
+  /// - Parameters:
+  ///   - other: The value to which `self` is compared.
+  ///   - relativeTolerance: The relative tolerance to use in the comparison.
+  ///   If no relativeTolerance is provided, zero is used.
+  ///   This value should be non-negative and less than or equal to 1.
+  ///   This constraint on is only checked in debug builds, because a mathematically
+  ///   well-defined result exists for any tolerance, even one out of range.
+  ///   - absoluteTolerance: The absolute tolerance to use in the comparison.
+  ///   This value should be non-negative and finite.
+  ///   This constraint on is only checked in debug builds, because a mathematically
+  ///   well-defined result exists for any tolerance, even one out of range.
   @inlinable
   public func isApproximatelyEqual(
     to other: Self,

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -10,107 +10,22 @@
 //===----------------------------------------------------------------------===//
 
 extension Numeric where Magnitude: FloatingPoint {
-  /// Compares `self` and `other` for approximate equality with default
-  /// tolerances.
-  ///
-  /// `a.isApproximatelyEqual(to: b)` is `true` if `a` and `b`
-  /// are equal, or if both are finite and `|a - b| ≤ √u * max(|a|,|b|,n)`,
-  /// where `||` is the norm computed by the `.magnitude` property,
-  /// `u` is `.ulpOfOne`, and `n` is `.leastNormalMagnitude`.
-  ///
-  /// Due to rounding of intermediate results, "the same" value computed using
-  /// two different techniques frequently has slightly different results in
-  /// floating-point arithmetic. This comparison method may be helpful in
-  /// these situations.
-  ///
-  /// ```
-  /// a.isApproximatelyEqual(to: b)
-  /// ```
-  /// is true if `a ` and `b` agree to about half the representable
-  /// significant digits, which is the usual naive guidance in numerical
-  /// analysis ("if you don't have a careful analysis, half your bits
-  /// are probably bad").
-  ///
-  /// More precisely, the call shown above is exactly equivalent to:
-  /// ```
-  /// let rtol = Magnitude.ulpOfOne.squareRoot()
-  /// a.isApproximatelyEqual(to: b, relativeTolerance: rtol)
-  /// ```
-  /// or:
-  /// ```
-  /// let rtol = Magnitude.ulpOfOne.squareRoot()
-  /// let atol = Magnitude.leastNormalMagnitude * rtol
-  /// a.isApproximatelyEqual(to: b,
-  ///   relativeTolerance: rtol,
-  ///   absoluteTolerance: atol
-  /// )
-  /// ```
-  /// Consult the documentation for those methods for a detailed
-  /// description of how the comparison is performed, and how to
-  /// choose tolerances for your particular situation.
-  ///
-  /// Mathematical Properties:
-  /// -
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _reflexive_ for
-  ///   non-exceptional values (such as NaN).
-  ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _symmetric_.
-  ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is __not__ _transitive_.
-  ///   Because of this, approximately equality is __not an equivalence relation__,
-  ///   even when restricted to non-exceptional values.
-  ///
-  /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
-  ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
-  ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:)` is _scale invariant_,
-  ///   so long as no underflow or overflow occurs, and no exceptional value is produced
-  ///   by the scaling.
-  ///
-  /// - Parameters:
-  ///   - other: The value to which `self` is compared.
-  ///
-  @inlinable @inline(__always)
-  public func isApproximatelyEqual(
-    to other: Self
-  ) -> Bool {
-    return isApproximatelyEqual(
-      to: other,
-      relativeTolerance: Magnitude.ulpOfOne.squareRoot()
-    )
-  }
-  
   /// Compares `self` and `other` for approximate equality with a specified
   /// relative tolerance and implicit absolute tolerance.
   ///
-  /// If we ignore underflow and overflow for the moment, floating-point arithmetic
-  /// is scale-invariant. Because of this, a _relative_ comparison usually
-  /// makes the most sense when defining approximate equality.
+  /// `true` if `self` and `other` are equal, or if they are finite and
+  /// ```
+  /// (self - other).magnitude ≤ relativeTolerance * scale
+  /// ```
+  /// where `scale` is
+  /// ```
+  /// max(self.magnitude, other.magnitude, .leastNormalMagnitude)
+  /// ```
   ///
-  /// Normally in mathematics, comparison for relative approximate equality looks like:
-  /// ```
-  /// |a - b| ≤ tolerance * max(|a|,|b|)
-  /// ```
-  /// where `|a|` is the magnitude of `a` measured by some _norm_.
-  ///
-  /// However, floating-point is not perfectly scale-invariant when underflow occurs,
-  /// so we slightly modify the definition of relative comparison to account for this,
-  /// and use the following instead:
-  /// ```
-  /// |a - b| ≤ tolerance * max(|a|,|b|,n)
-  /// ```
-  /// where `n` is `.leastNormalMagnitude`, or equivalently:
-  /// ```
-  /// |a - b| ≤ max(tolerance*n, tolerance*max(|a|,|b|))
-  /// ```
-  /// This means that the actual error allowed for all subnormal values is exactly
-  /// the tolerance allowed for the smallest normal value. If you want to avoid this
-  /// special handling for subnormal values, pass an explicit
-  /// `absoluteTolerance: 0` parameter.
-  ///
-  /// Scale-invariance also breaks down when overflow occurs, but in that case no
-  /// useful comparison is recoverable, so we simply do not try; infinity compares
-  /// not equal to any finite value with any allowed tolerance.
+  /// The default value of `relativeTolerance` is `.ulpOfOne.squareRoot()`,
+  /// which corresponds to expecting "about half the digits" in the computed results to be good.
+  /// This is the usual guidance in numerical analysis, if you don't know anything about the
+  /// computation being performed, but is not suitable for all use cases.
   ///
   /// Mathematical Properties:
   /// -
@@ -127,81 +42,75 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
   ///
   /// - `isApproximatelyEqual(to:relativeTolerance:)` is _scale invariant_,
-  ///   so long as no underflow or overflow occurs, and no exceptional value is produced
+  ///   so long as no underflow or overflow has occured, and no exceptional value is produced
   ///   by the scaling.
   ///
   /// - Parameters:
   ///   - other: The value to which `self` is compared.
   ///   - relativeTolerance: The tolerance to use for the comparison.
+  ///   If no tolerance is provided, `.ulpOfOne.squareRoot()` is used.
   ///   This value should be non-negative and less than or equal to 1.
   ///   This constraint on is only checked in debug builds, because a mathematically
   ///   well-defined result exists for any tolerance, even one out of range.
   @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
-    relativeTolerance: Magnitude
+    relativeTolerance: Magnitude = Magnitude.ulpOfOne.squareRoot()
   ) -> Bool {
     return isApproximatelyEqual(
       to: other,
-      relativeTolerance: relativeTolerance,
-      absoluteTolerance: relativeTolerance * Magnitude.leastNormalMagnitude
+      absoluteTolerance: relativeTolerance * Magnitude.leastNormalMagnitude,
+      relativeTolerance: relativeTolerance
     )
   }
   
   /// Compares `self` and `other` for approximate equality with a specified tolerances.
   ///
-  /// `a.isApproximatelyEqual(to: b, relativeTolerance: rtol, absoluteTolerance: atol)`
-  /// is `true` if a and b are equal, or if they are finite and
+  /// `true` if `self` and `other` are equal, or if they are finite and either
   /// ```
-  /// |a - b| ≤ max(atol, rtol * max(|a|,|b|))
+  /// (self - other).magnitude ≤ absoluteTolerance
   /// ```
-  /// This is equivalent to saying that the comparison satisfies _either_ the absolute tolerance,
-  /// _or_ the relative tolerance; it need not satisfy both:
+  /// or
   /// ```
-  /// |a - b| ≤ atol OR |a - b| ≤ rtol * max(|a|,|b|)
+  /// (self - other).magnitude ≤ relativeTolerance * scale
   /// ```
-  ///
-  /// If `relativeTolerance` is omitted or is zero, a pure absolute tolerance is used:
-  /// ```
-  /// |a - b| ≤ atol
-  /// ```
-  ///
-  /// If `absoluteTolerance` is zero, a pure relative tolerance is used:
-  /// ```
-  /// |a - b| ≤ rtol * max(|a|,|b|)
-  /// ```
+  /// where `scale` is `max(self.magnitude, other.magnitude)`.
   ///
   /// Mathematical Properties:
   /// -
-  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:)`
   ///   is _reflexive_ for non-exceptional values (such as NaN).
   ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:)`
   ///   is _symmetric_.
   ///
-  /// - `isApproximatelyEqual(to:relativeTolerance:absoluteTolerance:)`
+  /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:)`
   ///   is __not__ _transitive_. Because of this, approximately equality is
   ///   __not an equivalence relation__, even when restricted to non-exceptional values.
   ///
   /// - For any point `a`, the set of values that compare approximately equal to `a` is _convex_.
-  ///   (Under the assumption that the `.magnitude` property implements a valid norm.)
+  ///   (Under the assumption that `norm` implements a valid norm, which cannot be checked
+  ///   by this function.)
   ///
   /// - Parameters:
   ///   - other: The value to which `self` is compared.
+  ///   - absoluteTolerance: The absolute tolerance to use in the comparison.
+  ///   This value should be non-negative and finite.
+  ///   This constraint on is only checked in debug builds, because a mathematically
+  ///   well-defined result exists for any tolerance, even one out of range.
   ///   - relativeTolerance: The relative tolerance to use in the comparison.
   ///   If no relativeTolerance is provided, zero is used.
   ///   This value should be non-negative and less than or equal to 1.
   ///   This constraint on is only checked in debug builds, because a mathematically
   ///   well-defined result exists for any tolerance, even one out of range.
-  ///   - absoluteTolerance: The absolute tolerance to use in the comparison.
-  ///   This value should be non-negative and finite.
-  ///   This constraint on is only checked in debug builds, because a mathematically
-  ///   well-defined result exists for any tolerance, even one out of range.
-  @inlinable
+  ///   - norm: Allows you to specify what norm to use. Defaults to using the
+  ///   `.magnitude` property.
+  @inlinable @inline(__always)
   public func isApproximatelyEqual(
     to other: Self,
+    absoluteTolerance: Magnitude,
     relativeTolerance: Magnitude = 0,
-    absoluteTolerance: Magnitude
+    norm: (Self) -> Magnitude = { $0.magnitude }
   ) -> Bool {
     assert(
       absoluteTolerance >= 0 && absoluteTolerance.isFinite,
@@ -214,8 +123,8 @@ extension Numeric where Magnitude: FloatingPoint {
       "but is \(relativeTolerance)."
     )
     if self == other { return true }
-    let delta = (self - other).magnitude
-    let scale = max(self.magnitude, other.magnitude)
+    let delta = norm(self - other)
+    let scale = max(norm(self), norm(other))
     let bound = max(absoluteTolerance, scale*relativeTolerance)
     return delta.isFinite && delta <= bound
   }

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -83,7 +83,7 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   return (a - b).magnitude < t * scale
   ///   ```
   ///   The tolerance `t` must be in `.ulpOfOne ..< 1`.  The `minimumScale` must
-  ///   be positive and finite.
+  ///   be non-negative and finite.
   ///
   /// - Parameters:
   ///   - other: The value to compare.
@@ -103,7 +103,7 @@ extension Numeric where Magnitude: FloatingPoint {
       return delta < atol
     case let .relative(rtol, floor):
       assert(rtol >= .ulpOfOne && rtol < 1, "Relative tolerance must be in [.ulpOfOne, 1).")
-      assert(floor >= 0 && floor.isFinite, "Minimum scale must be positive and finite.")
+      assert(floor >= 0 && floor.isFinite, "Minimum scale must be non-negative and finite.")
       let scale = max(self.magnitude, other.magnitude, floor)
       return delta < scale*rtol
     }

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -1,0 +1,50 @@
+//===--- ApproximateEquality.swift ----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A tolerance to use for approximate comparisons
+///
+/// These values are consumed by the `approximatelyEquals` method defined on `Numeric`
+/// whenever the `Magnitude` associated type conforms to floating-point.
+public enum Tolerance<T: FloatingPoint> {
+  case relative(_ tolerance: T = T.ulpOfOne.squareRoot(), minimumScale: T = .leastNormalMagnitude)
+  case absolute(_ tolerance: T = T.ulpOfOne.squareRoot())
+}
+
+extension Numeric where Magnitude: FloatingPoint {
+  /// Approximate equality comparison
+  ///
+  /// Due to rounding of intermediate results, "the same" value computed using two different techniques
+  /// frequently has a slightly different result in floating-point arithmetic. This comparison method may
+  /// be helpful in these situations.
+  ///
+  /// By default, this method performs a relative comparison with a minimum scale set to the underflow
+  /// threshold and a tolerance of √ulpOfOne. This is as sensible a default as any.
+  @inlinable
+  public func approximatelyEquals(
+    _ other: Self,
+    tolerance: Tolerance<Magnitude> = .relative()
+  ) -> Bool {
+    // If a and b are actually equal, then they are certainly *almost* equal,
+    // with any allowable tolerance.
+    if self == other { return true }
+    let delta = (self - other).magnitude
+    switch tolerance {
+    case let .absolute(atol):
+      assert(atol > 0 && atol.isFinite, "Absolute tolerance must be positive and finite.")
+      return delta < atol
+    case let .relative(rtol, floor):
+      assert(rtol >= .ulpOfOne && rtol < 1, "Relative tolerance must be in [.ulpOfOne, 1).")
+      assert(floor >= 0 && floor.isFinite, "Minimum scale must be positive and finite.")
+      let scale = max(self.magnitude, other.magnitude, floor)
+      return delta < scale*rtol
+    }
+  }
+}

--- a/Sources/RealModule/CMakeLists.txt
+++ b/Sources/RealModule/CMakeLists.txt
@@ -9,6 +9,7 @@ See https://swift.org/LICENSE.txt for license information
 
 add_library(RealModule
   AlgebraicField.swift
+  ApproximateEquality.swift
   Double+Real.swift
   ElementaryFunctions.swift
   Float+Real.swift

--- a/Tests/ComplexTests/ApproximateEqualityTests.swift
+++ b/Tests/ComplexTests/ApproximateEqualityTests.swift
@@ -1,0 +1,38 @@
+import Numerics
+import XCTest
+
+final class ElementaryFunctionTests: XCTestCase {
+  
+  func testSpecials<T: Real>(tolerance tol: Tolerance<T>) {
+    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(.zero, tolerance: tol))
+    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(-.zero, tolerance: tol))
+    XCTAssertTrue((-Complex<T>.zero).approximatelyEquals(.zero, tolerance: tol))
+    XCTAssertTrue((-Complex<T>.zero).approximatelyEquals(-.zero, tolerance: tol))
+    XCTAssertTrue(Complex<T>.infinity.approximatelyEquals(.infinity, tolerance: tol))
+    XCTAssertTrue((-Complex<T>.infinity).approximatelyEquals(-.infinity, tolerance: tol))
+    // Complex has a single point at infinity.
+    XCTAssertTrue(Complex<T>.infinity.approximatelyEquals(-.infinity, tolerance: tol))
+    XCTAssertTrue((-Complex<T>.infinity).approximatelyEquals(.infinity, tolerance: tol))
+  }
+  
+  func testSpecials<T: Real>(_ type: T.Type) {
+    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(.zero))
+    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(-.zero))
+    testSpecials(tolerance: .absolute(T.zero))
+    testSpecials(tolerance: .absolute(T.greatestFiniteMagnitude))
+    testSpecials(tolerance: .relative(T.ulpOfOne))
+    testSpecials(tolerance: .relative(T(1).nextDown))
+  }
+  
+  func testFloat() {
+    testSpecials(Float.self)
+  }
+  
+  func testDouble() {
+    testSpecials(Double.self)
+  }
+  
+  func testFloat80() {
+    testSpecials(Float80.self)
+  }
+}

--- a/Tests/ComplexTests/ApproximateEqualityTests.swift
+++ b/Tests/ComplexTests/ApproximateEqualityTests.swift
@@ -3,25 +3,41 @@ import XCTest
 
 final class ElementaryFunctionTests: XCTestCase {
   
-  func testSpecials<T: Real>(tolerance tol: Tolerance<T>) {
-    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(.zero, tolerance: tol))
-    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(-.zero, tolerance: tol))
-    XCTAssertTrue((-Complex<T>.zero).approximatelyEquals(.zero, tolerance: tol))
-    XCTAssertTrue((-Complex<T>.zero).approximatelyEquals(-.zero, tolerance: tol))
-    XCTAssertTrue(Complex<T>.infinity.approximatelyEquals(.infinity, tolerance: tol))
-    XCTAssertTrue((-Complex<T>.infinity).approximatelyEquals(-.infinity, tolerance: tol))
+  func testSpecials<T: Real>(absolute tol: T) {
+    let zero = Complex<T>.zero
+    let inf = Complex<T>.infinity
+    XCTAssertTrue(zero.isApproximatelyEqual(to: zero, absoluteTolerance: tol))
+    XCTAssertTrue(zero.isApproximatelyEqual(to:-zero, absoluteTolerance: tol))
+    XCTAssertTrue((-zero).isApproximatelyEqual(to: zero, absoluteTolerance: tol))
+    XCTAssertTrue((-zero).isApproximatelyEqual(to:-zero, absoluteTolerance: tol))
     // Complex has a single point at infinity.
-    XCTAssertTrue(Complex<T>.infinity.approximatelyEquals(-.infinity, tolerance: tol))
-    XCTAssertTrue((-Complex<T>.infinity).approximatelyEquals(.infinity, tolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, absoluteTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to:-inf, absoluteTolerance: tol))
+    XCTAssertTrue((-inf).isApproximatelyEqual(to: inf, absoluteTolerance: tol))
+    XCTAssertTrue((-inf).isApproximatelyEqual(to:-inf, absoluteTolerance: tol))
+  }
+  
+  func testSpecials<T: Real>(relative tol: T) {
+    let zero = Complex<T>.zero
+    let inf = Complex<T>.infinity
+    XCTAssertTrue(zero.isApproximatelyEqual(to: zero, relativeTolerance: tol))
+    XCTAssertTrue(zero.isApproximatelyEqual(to:-zero, relativeTolerance: tol))
+    XCTAssertTrue((-zero).isApproximatelyEqual(to: zero, relativeTolerance: tol))
+    XCTAssertTrue((-zero).isApproximatelyEqual(to:-zero, relativeTolerance: tol))
+    // Complex has a single point at infinity.
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, relativeTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to:-inf, relativeTolerance: tol))
+    XCTAssertTrue((-inf).isApproximatelyEqual(to: inf, relativeTolerance: tol))
+    XCTAssertTrue((-inf).isApproximatelyEqual(to:-inf, relativeTolerance: tol))
   }
   
   func testSpecials<T: Real>(_ type: T.Type) {
-    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(.zero))
-    XCTAssertTrue(Complex<T>.zero.approximatelyEquals(-.zero))
-    testSpecials(tolerance: .absolute(T.zero))
-    testSpecials(tolerance: .absolute(T.greatestFiniteMagnitude))
-    testSpecials(tolerance: .relative(T.ulpOfOne))
-    testSpecials(tolerance: .relative(T(1).nextDown))
+    XCTAssertTrue(Complex<T>.zero.isApproximatelyEqual(to: .zero))
+    XCTAssertTrue(Complex<T>.zero.isApproximatelyEqual(to:-.zero))
+    testSpecials(absolute: T.zero)
+    testSpecials(absolute: T.greatestFiniteMagnitude)
+    testSpecials(relative: T.ulpOfOne)
+    testSpecials(relative: T(1))
   }
   
   func testFloat() {

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -165,12 +165,10 @@ final class ArithmeticTests: XCTestCase {
       let a: Complex<Double>
       let b: Complex<Double>
       let c: Complex<Double>
-      let allowSmallError: Bool
-      init(_ a: Complex<Double>, _ b: Complex<Double>, _ c: Complex<Double>, allowSmallError: Bool = false) {
+      init(_ a: Complex<Double>, _ b: Complex<Double>, _ c: Complex<Double>) {
         self.a = a
         self.b = b
         self.c = c
-        self.allowSmallError = allowSmallError
       }
     }
     // The ten test cases from Baudin & Smith's paper. These only apply to

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -40,10 +40,10 @@ final class ElementaryFunctionTests: XCTestCase {
     XCTAssertTrue(T(1).approximatelyEquals(1 - e/2, tolerance: .relative()))
     XCTAssertFalse(T(1).approximatelyEquals(1 + 2*e, tolerance: .relative()))
     XCTAssertFalse(T(1).approximatelyEquals(1 - e, tolerance: .relative()))
-    XCTAssertTrue(T(1).approximatelyEquals((1 + e).nextDown, tolerance: .absolute()))
-    XCTAssertTrue(T(1).approximatelyEquals((1 - e).nextUp, tolerance: .absolute()))
-    XCTAssertFalse(T(1).approximatelyEquals((1 + e).nextUp, tolerance: .absolute()))
-    XCTAssertFalse(T(1).approximatelyEquals((1 - e).nextDown, tolerance: .absolute()))
+    XCTAssertTrue(T(1).approximatelyEquals((1 + e).nextDown, tolerance: .absolute(e)))
+    XCTAssertTrue(T(1).approximatelyEquals((1 - e).nextUp, tolerance: .absolute(e)))
+    XCTAssertFalse(T(1).approximatelyEquals((1 + e).nextUp, tolerance: .absolute(e)))
+    XCTAssertFalse(T(1).approximatelyEquals((1 - e).nextDown, tolerance: .absolute(e)))
   }
   
   func testRandom<T>(_ type: T.Type) where T: FixedWidthFloatingPoint & Real {

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -3,47 +3,52 @@ import XCTest
 
 final class ElementaryFunctionTests: XCTestCase {
   
-  func testSpecials<T: Real>(tolerance tol: Tolerance<T>) {
-    XCTAssertTrue(T.zero.approximatelyEquals(.zero, tolerance: tol))
-    XCTAssertTrue( T.zero.approximatelyEquals(-.zero, tolerance: tol))
-    XCTAssertTrue((-T.zero).approximatelyEquals(.zero, tolerance: tol))
-    XCTAssertTrue((-T.zero).approximatelyEquals(-.zero, tolerance: tol))
-    XCTAssertTrue( T.infinity.approximatelyEquals(.infinity, tolerance: tol))
-    XCTAssertTrue((-T.infinity).approximatelyEquals(-.infinity, tolerance: tol))
-    XCTAssertFalse( T.infinity.approximatelyEquals(.greatestFiniteMagnitude, tolerance: tol))
-    XCTAssertFalse( T.greatestFiniteMagnitude.approximatelyEquals(.infinity, tolerance: tol))
-    XCTAssertFalse((-T.infinity).approximatelyEquals(-.greatestFiniteMagnitude, tolerance: tol))
-    XCTAssertFalse((-T.greatestFiniteMagnitude).approximatelyEquals(-.infinity, tolerance: tol))
-    XCTAssertFalse( T.infinity.approximatelyEquals(-.infinity, tolerance: tol))
-    XCTAssertFalse((-T.infinity).approximatelyEquals(.infinity, tolerance: tol))
-    XCTAssertFalse( T.nan.approximatelyEquals(.nan, tolerance: tol))
+  func testSpecials<T: Real>(absolute tol: T) {
+    let zero = T.zero
+    let gfm = T.greatestFiniteMagnitude
+    let inf = T.infinity
+    let nan = T.nan
+    XCTAssertTrue(zero.isApproximatelyEqual(to: zero, absoluteTolerance: tol))
+    XCTAssertTrue(zero.isApproximatelyEqual(to:-zero, absoluteTolerance: tol))
+    XCTAssertFalse(inf.isApproximatelyEqual(to: gfm, absoluteTolerance: tol))
+    XCTAssertFalse(gfm.isApproximatelyEqual(to: inf, absoluteTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, absoluteTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, absoluteTolerance: tol))
+    XCTAssertFalse(nan.isApproximatelyEqual(to: nan, absoluteTolerance: tol))
+  }
+  
+  func testSpecials<T: Real>(relative tol: T) {
+    let zero = T.zero
+    let gfm = T.greatestFiniteMagnitude
+    let inf = T.infinity
+    let nan = T.nan
+    XCTAssertTrue(zero.isApproximatelyEqual(to: zero, relativeTolerance: tol))
+    XCTAssertTrue(zero.isApproximatelyEqual(to:-zero, relativeTolerance: tol))
+    XCTAssertFalse(inf.isApproximatelyEqual(to: gfm, relativeTolerance: tol))
+    XCTAssertFalse(gfm.isApproximatelyEqual(to: inf, relativeTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, relativeTolerance: tol))
+    XCTAssertTrue(inf.isApproximatelyEqual(to: inf, relativeTolerance: tol))
+    XCTAssertFalse(nan.isApproximatelyEqual(to: nan, relativeTolerance: tol))
   }
   
   func testSpecials<T: Real>(_ type: T.Type) {
-    XCTAssertTrue( T.zero.approximatelyEquals(.zero))
-    XCTAssertTrue( T.zero.approximatelyEquals(-.zero))
-    XCTAssertTrue((-T.zero).approximatelyEquals(.zero))
-    XCTAssertTrue((-T.zero).approximatelyEquals(-.zero))
-    testSpecials(tolerance: .absolute(T.leastNormalMagnitude))
-    testSpecials(tolerance: .absolute(T.greatestFiniteMagnitude))
-    testSpecials(tolerance: .relative(T.ulpOfOne))
-    testSpecials(tolerance: .relative(T(1).nextDown))
+    XCTAssertTrue(T.zero.isApproximatelyEqual(to: .zero))
+    XCTAssertTrue(T.zero.isApproximatelyEqual(to:-.zero))
+    testSpecials(absolute: T.zero)
+    testSpecials(absolute: T.leastNormalMagnitude)
+    testSpecials(absolute: T.greatestFiniteMagnitude)
+    testSpecials(relative: T.zero)
+    testSpecials(relative: T.ulpOfOne)
+    testSpecials(relative: T(1).nextDown)
+    testSpecials(relative: T(1))
   }
-  
+
   func testDefaults<T: Real>(_ type: T.Type) {
-    let e = T.sqrt(.ulpOfOne)
-    XCTAssertTrue(T(1).approximatelyEquals(1 + e))
-    XCTAssertTrue(T(1).approximatelyEquals(1 - e/2))
-    XCTAssertFalse(T(1).approximatelyEquals(1 + 2*e))
-    XCTAssertFalse(T(1).approximatelyEquals(1 - e))
-    XCTAssertTrue(T(1).approximatelyEquals(1 + e, tolerance: .relative()))
-    XCTAssertTrue(T(1).approximatelyEquals(1 - e/2, tolerance: .relative()))
-    XCTAssertFalse(T(1).approximatelyEquals(1 + 2*e, tolerance: .relative()))
-    XCTAssertFalse(T(1).approximatelyEquals(1 - e, tolerance: .relative()))
-    XCTAssertTrue(T(1).approximatelyEquals((1 + e).nextDown, tolerance: .absolute(e)))
-    XCTAssertTrue(T(1).approximatelyEquals((1 - e).nextUp, tolerance: .absolute(e)))
-    XCTAssertFalse(T(1).approximatelyEquals((1 + e).nextUp, tolerance: .absolute(e)))
-    XCTAssertFalse(T(1).approximatelyEquals((1 - e).nextDown, tolerance: .absolute(e)))
+    let e = T.ulpOfOne.squareRoot()
+    XCTAssertTrue(T(1).isApproximatelyEqual(to: 1 + e))
+    XCTAssertTrue(T(1).isApproximatelyEqual(to: 1 - e/2))
+    XCTAssertFalse(T(1).isApproximatelyEqual(to: 1 + 2*e))
+    XCTAssertFalse(T(1).isApproximatelyEqual(to: 1 - 3*e/2))
   }
   
   func testRandom<T>(_ type: T.Type) where T: FixedWidthFloatingPoint & Real {
@@ -51,25 +56,29 @@ final class ElementaryFunctionTests: XCTestCase {
     // Generate a bunch of random values in a small interval and a tolerance
     // and use them to check that various properties that we would like to
     // hold actually do.
-    var values = [1] + (0 ..< 64).map { _ in T.random(in: 1 ..< 2, using: &g) } + [2]
-    values.sort()
+    var x = [1] + (0 ..< 64).map {
+      _ in T.random(in: 1 ..< 2, using: &g)
+    } + [2]
+    x.sort()
     // We have 66 values in 1 ... 2, so if we use a tolerance of around 1/64,
     // at least some of the pairs will compare equal with tolerance.
     let tol = T.random(in: 1/64 ... 1/32, using: &g)
     // We're going to walk the values in order, validating that some common-
     // sense properties hold.
-    for i in values.indices {
+    for i in x.indices {
       // reflexivity
-      XCTAssertTrue(values[i].approximatelyEquals(values[i], tolerance: .absolute(tol)))
-      for j in i ..< values.endIndex {
+      XCTAssertTrue(x[i].isApproximatelyEqual(to: x[i]))
+      XCTAssertTrue(x[i].isApproximatelyEqual(to: x[i], relativeTolerance: tol))
+      XCTAssertTrue(x[i].isApproximatelyEqual(to: x[i], absoluteTolerance: tol))
+      for j in i ..< x.endIndex {
         // commutativity
         XCTAssertTrue(
-          values[i].approximatelyEquals(values[j], tolerance: .relative(tol)) ==
-          values[j].approximatelyEquals(values[i], tolerance: .relative(tol))
+          x[i].isApproximatelyEqual(to: x[j], relativeTolerance: tol) ==
+          x[j].isApproximatelyEqual(to: x[i], relativeTolerance: tol)
         )
         XCTAssertTrue(
-          values[i].approximatelyEquals(values[j], tolerance: .absolute(tol)) ==
-          values[j].approximatelyEquals(values[i], tolerance: .absolute(tol))
+          x[i].isApproximatelyEqual(to: x[j], absoluteTolerance: tol) ==
+          x[j].isApproximatelyEqual(to: x[i], absoluteTolerance: tol)
         )
         // scale invariance for relative comparisons
         let scale = T(
@@ -78,20 +87,24 @@ final class ElementaryFunctionTests: XCTestCase {
           significand: 1
         )
         XCTAssertTrue(
-          (scale*values[i]).approximatelyEquals(scale*values[j], tolerance: .relative(tol)) ==
-          (scale*values[j]).approximatelyEquals(scale*values[i], tolerance: .relative(tol))
+          x[i].isApproximatelyEqual(to: x[j], relativeTolerance: tol) ==
+          (scale*x[i]).isApproximatelyEqual(to: scale*x[j], relativeTolerance: tol)
         )
       }
-      // if a ≤ b ≤ c, and a ≈ c, then a ≈ b and b ≈ c
-      for t in [Tolerance.relative(tol), .absolute(tol)] {
-        guard let left = values.firstIndex(where: {
-          values[i].approximatelyEquals($0, tolerance: t)
-        }) else { continue }
-        let right = values.lastIndex {
-          values[i].approximatelyEquals($0, tolerance: t)
-        }! // don't need guard because we found left
-        for j in left ... right {
-          XCTAssertTrue(values[i].approximatelyEquals(values[j], tolerance: t))
+      // if a ≤ b ≤ c, and a ≈ c, then a ≈ b and b ≈ c (relative tolerance)
+      var left = x.firstIndex { x[i].isApproximatelyEqual(to: $0, relativeTolerance: tol) }
+      var right = x.lastIndex { x[i].isApproximatelyEqual(to: $0, relativeTolerance: tol) }
+      if let l = left, let r = right {
+        for j in l ..< r {
+          XCTAssertTrue(x[i].isApproximatelyEqual(to: x[j], relativeTolerance: tol))
+        }
+      }
+      // if a ≤ b ≤ c, and a ≈ c, then a ≈ b and b ≈ c (absolute tolerance)
+      left = x.firstIndex { x[i].isApproximatelyEqual(to: $0, absoluteTolerance: tol) }
+      right = x.lastIndex { x[i].isApproximatelyEqual(to: $0, absoluteTolerance: tol) }
+      if let l = left, let r = right {
+        for j in l ..< r {
+          XCTAssertTrue(x[i].isApproximatelyEqual(to: x[j], absoluteTolerance: tol))
         }
       }
     }

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -1,0 +1,117 @@
+import RealModule
+import XCTest
+
+final class ElementaryFunctionTests: XCTestCase {
+  
+  func testSpecials<T: Real>(tolerance tol: Tolerance<T>) {
+    XCTAssertTrue(T.zero.approximatelyEquals(.zero, tolerance: tol))
+    XCTAssertTrue( T.zero.approximatelyEquals(-.zero, tolerance: tol))
+    XCTAssertTrue((-T.zero).approximatelyEquals(.zero, tolerance: tol))
+    XCTAssertTrue((-T.zero).approximatelyEquals(-.zero, tolerance: tol))
+    XCTAssertTrue( T.infinity.approximatelyEquals(.infinity, tolerance: tol))
+    XCTAssertTrue((-T.infinity).approximatelyEquals(-.infinity, tolerance: tol))
+    XCTAssertFalse( T.infinity.approximatelyEquals(.greatestFiniteMagnitude, tolerance: tol))
+    XCTAssertFalse( T.greatestFiniteMagnitude.approximatelyEquals(.infinity, tolerance: tol))
+    XCTAssertFalse((-T.infinity).approximatelyEquals(-.greatestFiniteMagnitude, tolerance: tol))
+    XCTAssertFalse((-T.greatestFiniteMagnitude).approximatelyEquals(-.infinity, tolerance: tol))
+    XCTAssertFalse( T.infinity.approximatelyEquals(-.infinity, tolerance: tol))
+    XCTAssertFalse((-T.infinity).approximatelyEquals(.infinity, tolerance: tol))
+    XCTAssertFalse( T.nan.approximatelyEquals(.nan, tolerance: tol))
+  }
+  
+  func testSpecials<T: Real>(_ type: T.Type) {
+    XCTAssertTrue( T.zero.approximatelyEquals(.zero))
+    XCTAssertTrue( T.zero.approximatelyEquals(-.zero))
+    XCTAssertTrue((-T.zero).approximatelyEquals(.zero))
+    XCTAssertTrue((-T.zero).approximatelyEquals(-.zero))
+    testSpecials(tolerance: .absolute(T.leastNormalMagnitude))
+    testSpecials(tolerance: .absolute(T.greatestFiniteMagnitude))
+    testSpecials(tolerance: .relative(T.ulpOfOne))
+    testSpecials(tolerance: .relative(T(1).nextDown))
+  }
+  
+  func testDefaults<T: Real>(_ type: T.Type) {
+    let e = T.sqrt(.ulpOfOne)
+    XCTAssertTrue(T(1).approximatelyEquals(1 + e))
+    XCTAssertTrue(T(1).approximatelyEquals(1 - e/2))
+    XCTAssertFalse(T(1).approximatelyEquals(1 + 2*e))
+    XCTAssertFalse(T(1).approximatelyEquals(1 - e))
+    XCTAssertTrue(T(1).approximatelyEquals(1 + e, tolerance: .relative()))
+    XCTAssertTrue(T(1).approximatelyEquals(1 - e/2, tolerance: .relative()))
+    XCTAssertFalse(T(1).approximatelyEquals(1 + 2*e, tolerance: .relative()))
+    XCTAssertFalse(T(1).approximatelyEquals(1 - e, tolerance: .relative()))
+    XCTAssertTrue(T(1).approximatelyEquals((1 + e).nextDown, tolerance: .absolute()))
+    XCTAssertTrue(T(1).approximatelyEquals((1 - e).nextUp, tolerance: .absolute()))
+    XCTAssertFalse(T(1).approximatelyEquals((1 + e).nextUp, tolerance: .absolute()))
+    XCTAssertFalse(T(1).approximatelyEquals((1 - e).nextDown, tolerance: .absolute()))
+  }
+  
+  func testRandom<T>(_ type: T.Type) where T: FixedWidthFloatingPoint & Real {
+    var g = SystemRandomNumberGenerator()
+    // Generate a bunch of random values in a small interval and a tolerance
+    // and use them to check that various properties that we would like to
+    // hold actually do.
+    var values = [1] + (0 ..< 64).map { _ in T.random(in: 1 ..< 2, using: &g) } + [2]
+    values.sort()
+    // We have 66 values in 1 ... 2, so if we use a tolerance of around 1/64,
+    // at least some of the pairs will compare equal with tolerance.
+    let tol = T.random(in: 1/64 ... 1/32, using: &g)
+    // We're going to walk the values in order, validating that some common-
+    // sense properties hold.
+    for i in values.indices {
+      // reflexivity
+      XCTAssertTrue(values[i].approximatelyEquals(values[i], tolerance: .absolute(tol)))
+      for j in i ..< values.endIndex {
+        // commutativity
+        XCTAssertTrue(
+          values[i].approximatelyEquals(values[j], tolerance: .relative(tol)) ==
+          values[j].approximatelyEquals(values[i], tolerance: .relative(tol))
+        )
+        XCTAssertTrue(
+          values[i].approximatelyEquals(values[j], tolerance: .absolute(tol)) ==
+          values[j].approximatelyEquals(values[i], tolerance: .absolute(tol))
+        )
+        // scale invariance for relative comparisons
+        let scale = T(
+          sign:.plus,
+          exponent: T.Exponent.random(in: T.leastNormalMagnitude.exponent ... T.greatestFiniteMagnitude.exponent),
+          significand: 1
+        )
+        XCTAssertTrue(
+          (scale*values[i]).approximatelyEquals(scale*values[j], tolerance: .relative(tol)) ==
+          (scale*values[j]).approximatelyEquals(scale*values[i], tolerance: .relative(tol))
+        )
+      }
+      // if a ≤ b ≤ c, and a ≈ c, then a ≈ b and b ≈ c
+      for t in [Tolerance.relative(tol), .absolute(tol)] {
+        guard let left = values.firstIndex(where: {
+          values[i].approximatelyEquals($0, tolerance: t)
+        }) else { continue }
+        let right = values.lastIndex {
+          values[i].approximatelyEquals($0, tolerance: t)
+        }! // don't need guard because we found left
+        for j in left ... right {
+          XCTAssertTrue(values[i].approximatelyEquals(values[j], tolerance: t))
+        }
+      }
+    }
+  }
+  
+  func testFloat() {
+    testSpecials(Float.self)
+    testDefaults(Float.self)
+    testRandom(Float.self)
+  }
+  
+  func testDouble() {
+    testSpecials(Double.self)
+    testDefaults(Double.self)
+    testRandom(Double.self)
+  }
+  
+  func testFloat80() {
+    testSpecials(Float80.self)
+    testDefaults(Float80.self)
+    testRandom(Float80.self)
+  }
+}

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -83,7 +83,7 @@ final class ElementaryFunctionTests: XCTestCase {
         // scale invariance for relative comparisons
         let scale = T(
           sign:.plus,
-          exponent: T.Exponent.random(in: T.leastNormalMagnitude.exponent ... T.greatestFiniteMagnitude.exponent),
+          exponent: T.Exponent.random(in: T.leastNormalMagnitude.exponent ..< T.greatestFiniteMagnitude.exponent),
           significand: 1
         )
         XCTAssertTrue(

--- a/Tests/RealTests/CMakeLists.txt
+++ b/Tests/RealTests/CMakeLists.txt
@@ -8,6 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(RealTests
+  ApproximateEqualityTests.swift
   IntegerExponentTests.swift
   RealTests.swift
   RealTestSupport.swift)

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -12,9 +12,11 @@
 import XCTest
 import RealModule
 
-internal extension Real where Self: BinaryFloatingPoint,
-                              Self.RawSignificand: FixedWidthInteger {
+internal extension Real where Self: FixedWidthFloatingPoint {
+  
   static func testIntegerExponentCommon() {
+    // TODO: replace with seedable generator, print seed.
+    var g = SystemRandomNumberGenerator()
     // If x is -1, then the result is ±1 with sign chosen by parity of n.
     // Simply converting n to Real will flip parity when n is large, so
     // first check that we get those cases right.
@@ -32,8 +34,9 @@ internal extension Real where Self: BinaryFloatingPoint,
     // underflow; we want to be sure that we get the right ±0 or ±∞
     // result.
     for _ in 0 ..< 10 {
-      let x = Self.random(in: 2 ..< 4)
-      let n = Int.random(in: 1 - Int(Self.leastNonzeroMagnitude.exponent) ..< .max)
+      let x = Self.random(in: 2 ..< 4, using: &g)
+      let nLowerBound = 1 - Int(Self.leastNonzeroMagnitude.exponent)
+      let n = Int.random(in: nLowerBound ..< .max, using: &g)
       let even = n & -2
       let odd = even | 1
       assertClose( .infinity, Self.pow(x, even))

--- a/Tests/RealTests/RealTestSupport.swift
+++ b/Tests/RealTests/RealTestSupport.swift
@@ -81,3 +81,19 @@ func assertClose<T>(
     expected, observed, allowedError: allowedError, file: file, line: line
   ))
 }
+
+internal protocol FixedWidthFloatingPoint: BinaryFloatingPoint
+where Exponent: FixedWidthInteger,
+      RawSignificand: FixedWidthInteger { }
+
+extension Float: FixedWidthFloatingPoint { }
+extension Double: FixedWidthFloatingPoint { }
+#if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
+extension Float80: FixedWidthFloatingPoint { }
+#endif
+
+extension FloatingPointSign {
+  static func random<G: RandomNumberGenerator>(using g: inout G) -> FloatingPointSign {
+    [.plus,.minus].randomElement(using: &g)!
+  }
+}


### PR DESCRIPTION
This is a revised version of SE-0259 with a somewhat simpler API--there's no more special-case handling for zero. It's also more general; it works for any Numeric type whose magnitude conforms to FloatingPoint. This is really nice, since it means that we get Complex and Quaternion support for free.

This new version tracks Julia's [`isapprox`](https://docs.julialang.org/en/v1/base/math/#Base.isapprox) pretty closely; my opinion is that this is the only language with an approximate comparison worth discussing. The divergences from what Julia does are as follows:

- Spelling. Julia is much terser than Swift =)
- Julia defaults to using the Euclidean norm. That's not available in this generic context, and while it's more common, it's actually a less-good choice due to overflow considerations, so I'm defaulting to using the `.magnitude` property.
- When only a relativeTolerance is provided, Julia defaults to absoluteTolerance = 0, but I'm defaulting to absoluteTolerance = relativeTolerance * .leastNormalMagnitude. Perfectly reasonable arguments can be made for both choices; using zero matches the mathematical notion of a pure relative tolerance, but scaling to .leastNormalMagnitude better tracks the actual rounding behavior of floating-point arithmetic.
- Julia falls back on elementwise comparison when `a-b` is non-finite, but that's not possible in Swift, because there's no notion of "element" in the generic context for which this function is defined. I fall back on `a == b` instead. Again, both of these are pretty reasonable choices (neither is great, to be honest, but neither is terrible, either).
- I am not providing the `nans` parameter for now (override behavior so that nan compares approximately equal to nan). This is easy to add later, but it's also an extra knob that I would prefer to keep out of the API if we can. I may very well end up turning around and adding it for testing purposes, however =)

Addresses https://github.com/apple/swift-numerics/issues/3