### PR TITLE
Refine Hashable and Equatable on Quaternion

### DIFF
--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -365,11 +365,15 @@ extension Quaternion: Hashable {
     return lhs.components == rhs.components
   }
 
-  /// Returns a Boolean value indicating whether the rotation in *R³* of this
-  /// quaternion equals the rotation of `other`.
+  /// Rotation equality comparison
   ///
   /// This method tests for rotation-wise equality in *R³*, where both `q == q`
-  /// but also `q == -q` is `true`.
+  /// but also `q == -q` are `true`.
+  ///
+  /// - Parameters:
+  ///   - other: The value to compare.
+  /// - Returns: Boolean value indicating whether the rotation in *R³* of this
+  /// quaternion equals the rotation of `other`.
   @_transparent
   public func rotationEquals(_ other: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -37,7 +37,7 @@ import RealModule
 /// important to be aware that, when used this way, any quaternion and its
 /// negation represent the same transformation, but they do not compare equal
 /// using `==` because they are not the same quaternion.
-/// You can compare quaternions as 3D transformations using `transformEquals()`.
+/// You can compare quaternions as 3D transformations using `equals(as3DTransform:)`.
 public struct Quaternion<RealType> where RealType: Real & SIMDScalar {
 
   /// The components of the 4-dimensional vector space of the quaternion.
@@ -401,7 +401,7 @@ extension Quaternion: Hashable {
   ///   important to be aware that, when used this way, any quaternion and its
   ///   negation represent the same transformation, but they do not compare
   ///   equal using `==` because they are not the same quaternion. You can
-  ///   compare quaternions as 3D transformations using `transformEquals()`.
+  ///   compare quaternions as 3D transformations using `equals(as3DTransform:)`.
   @_transparent
   public static func == (lhs: Quaternion, rhs: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".
@@ -413,13 +413,16 @@ extension Quaternion: Hashable {
     return lhs.components == rhs.components
   }
 
-  /// Transformation equality comparison
+  /// Returns a Boolean value indicating whether the 3D transformation of the
+  /// two quaternions are equal.
   ///
-  /// Returns a Boolean value indicating whether the 3D transformations of this
-  /// quaternion equals the 3D transformation of `other`.
+  /// Use this method to test for equality of the 3D transformation properties
+  /// of quaternions; where for any quaternion `q`, its negation represent the
+  /// same 3D transformation; i.e. `q.equals(as3DTransform: q)` as well as
+  /// `q.equals(as3DTransform: -q)` are both `true`.
   ///
   /// - Parameter other: The value to compare.
-  /// - Returns: True if the transformation of this quaternion equals `other`.
+  /// - Returns: True if the 3D transformation of this quaternion equals `other`.
   @_transparent
   public func equals(as3DTransform other: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -421,7 +421,7 @@ extension Quaternion: Hashable {
   /// - Parameter other: The value to compare.
   /// - Returns: True if the transformation of this quaternion equals `other`.
   @_transparent
-  public func transformEquals(_ other: Quaternion) -> Bool {
+  public func equals(as3DTransform other: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".
     guard isFinite || other.isFinite else { return true }
     // For finite numbers, equality is defined componentwise. Cases where only

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -33,9 +33,11 @@ import RealModule
 /// downsides. You can access the Euclidean norm using the `length` property.
 /// See `Complex` type of the swift-numerics package for additional details.
 ///
-/// `==` does not compare rotations in *R³*; it performs a componentwise and
-/// sign sensitive comparison. You can compare the rotations in *R³* of any
-/// two quaternions using `rotationEquals()`
+/// Quaternions are frequently used to represent 3D transformations. It's
+/// important to be aware that, when used this way, any quaternion and its
+/// negation represent the same transformation, but they do not compare equal
+/// using `==` because they are not the same quaternion.
+/// You can compare quaternions as 3D transformations using `transformEquals()`.
 public struct Quaternion<RealType> where RealType: Real & SIMDScalar {
 
   /// The components of the 4-dimensional vector space of the quaternion.
@@ -349,11 +351,11 @@ extension Quaternion: Hashable {
   /// `a == b` implies that `a != b` is `false`.
   ///
   /// - Important:
-  ///   This method does not compare rotations in *R³*, but rather performs
-  ///   a sign sensitive componentwise comparison. So for any *finite* value
-  ///   *q*, this method does **not** return `true` for `q == -q`.
-  ///   If you need to compare the rotations in *R³* of any two quaternions
-  ///   use `rotationEquals()`.
+  ///   Quaternions are frequently used to represent 3D transformations. It's
+  ///   important to be aware that, when used this way, any quaternion and its
+  ///   negation represent the same transformation, but they do not compare equal
+  ///   using `==` because they are not the same quaternion.
+  ///   You can compare quaternions as 3D transformations using `transformEquals()`.
   @_transparent
   public static func == (lhs: Quaternion, rhs: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -404,9 +404,9 @@ extension Quaternion: Hashable {
   /// - Important:
   ///   Quaternions are frequently used to represent 3D transformations. It's
   ///   important to be aware that, when used this way, any quaternion and its
-  ///   negation represent the same transformation, but they do not compare equal
-  ///   using `==` because they are not the same quaternion.
-  ///   You can compare quaternions as 3D transformations using `transformEquals()`.
+  ///   negation represent the same transformation, but they do not compare
+  ///   equal using `==` because they are not the same quaternion. You can
+  ///   compare quaternions as 3D transformations using `transformEquals()`.
   @_transparent
   public static func == (lhs: Quaternion, rhs: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".
@@ -418,21 +418,19 @@ extension Quaternion: Hashable {
     return lhs.components == rhs.components
   }
 
-  /// Rotation equality comparison
+  /// Transformation equality comparison
   ///
-  /// This method tests for rotation-wise equality in *R³*, where both `q == q`
-  /// but also `q == -q` are `true`.
+  /// Returns a Boolean value indicating whether the 3D transformations of this
+  /// quaternion equals the 3D transformation of `other`.
   ///
-  /// - Parameters:
-  ///   - other: The value to compare.
-  /// - Returns: Boolean value indicating whether the rotation in *R³* of this
-  /// quaternion equals the rotation of `other`.
+  /// - Parameter other: The value to compare.
+  /// - Returns: True if the transformation of this quaternion equals `other`.
   @_transparent
-  public func rotationEquals(_ other: Quaternion) -> Bool {
+  public func transformEquals(_ other: Quaternion) -> Bool {
     // Identify all numbers with either component non-finite as a single "point at infinity".
     guard isFinite || other.isFinite else { return true }
-    // For finite numbers, equality is defined componentwise. Cases where
-    // only one of lhs or rhs is infinite fall through to here as well, but this
+    // For finite numbers, equality is defined componentwise. Cases where only
+    // one of lhs or rhs is infinite fall through to here as well, but this
     // expression correctly returns false for them so we don't need to handle
     // them explicitly.
     return components == other.components || components == -other.components
@@ -452,7 +450,7 @@ extension Quaternion: Hashable {
     // (while unfortunately producing some collisions for people who are not,
     // but not in too catastrophic of a fashion).
     if isFinite {
-      transformCanonicalized.hash(into: &hasher)
+      transformCanonicalized.components.hash(into: &hasher)
     } else {
       hasher.combine(RealType.infinity)
     }

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -286,8 +286,8 @@ extension Quaternion {
   /// For normal quaternion instances with a RealType conforming to
   /// BinaryFloatingPoint (the common case) and a non-negative real component,
   /// the result is simply this value unmodified. For instances with a negative
-  /// real component, the result is a quaternion with a positive real component
-  /// of equal magnitude and an unmodified imaginary compontent (-r, x, y, z).
+  /// real component, the result is this quaternion negated -(r, x, y, z); so
+  /// the real component is always positive.
   /// For zeros, the result has the representation (+0, +0, +0, +0). For
   /// infinite values, the result has the representation (+inf, +0, +0, +0).
   ///
@@ -299,11 +299,9 @@ extension Quaternion {
   /// - `.canonicalized`
   @_transparent
   public var canonicalizedTransform: Self {
-    var canonical = canonicalized
+    let canonical = canonicalized
     if canonical.real.sign == .plus { return canonical }
-    // Clear the signbit of real even for -0
-    canonical.real.negate()
-    return canonical
+    return -canonical
   }
 }
 

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -270,11 +270,40 @@ extension Quaternion {
   /// before passing across language boundaries, but it may also be useful
   /// for some serialization tasks. It's also a useful implementation detail for
   /// some primitive operations.
+  ///
+  /// See also:
+  /// -
+  /// - `.transformCanonicalized`
   @_transparent
   public var canonicalized: Self {
     guard !isZero else { return .zero }
     guard isFinite else { return .infinity }
     return self.multiplied(by: 1)
+  }
+
+  /// A "canonical transformation" representation of the value.
+  ///
+  /// For normal quaternion instances with a RealType conforming to
+  /// BinaryFloatingPoint (the common case) and a non-negative real component,
+  /// the result is simply this value unmodified. For instances with a negative
+  /// real component, the result is a quaternion with a positive real component
+  /// of equal magnitude and an unmodified imaginary compontent (-r, x, y, z).
+  /// For zeros, the result has the representation (+0, +0, +0, +0). For
+  /// infinite values, the result has the representation (+inf, +0, +0, +0).
+  ///
+  /// If the RealType admits non-canonical representations, the x, y, z and r
+  /// components are canonicalized in the result.
+  ///
+  /// See also:
+  /// -
+  /// - `.canonicalized`
+  @_transparent
+  public var transformCanonicalized: Self {
+    var canonical = canonicalized
+    if canonical.real.sign == .plus { return canonical }
+    // Clear the signbit of real even for -0
+    canonical.real.negate()
+    return canonical
   }
 }
 

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -254,6 +254,28 @@ extension Quaternion {
   public var isPure: Bool {
     real.isZero
   }
+
+  /// A "canonical" representation of the value.
+  ///
+  /// For normal quaternion instances with a RealType conforming to
+  /// BinaryFloatingPoint (the common case), the result is simply this value
+  /// unmodified. For zeros, the result has the representation (+0, +0, +0, +0).
+  /// For infinite values, the result has the representation (+inf, +0, +0, +0).
+  ///
+  /// If the RealType admits non-canonical representations, the x, y, z and r
+  /// components are canonicalized in the result.
+  ///
+  /// This is mainly useful for interoperation with other languages, where
+  /// you may want to reduce each equivalence class to a single representative
+  /// before passing across language boundaries, but it may also be useful
+  /// for some serialization tasks. It's also a useful implementation detail for
+  /// some primitive operations.
+  @_transparent
+  public var canonicalized: Self {
+    guard !isZero else { return .zero }
+    guard isFinite else { return .infinity }
+    return self.multiplied(by: 1)
+  }
 }
 
 // MARK: - Additional Initializers

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -396,9 +396,6 @@ extension Quaternion where RealType: BinaryFloatingPoint {
 extension Quaternion: Hashable {
   /// Returns a Boolean value indicating whether two values are equal.
   ///
-  /// Equality is the inverse of inequality. For any values *a* and *b*,
-  /// `a == b` implies that `a != b` is `false`.
-  ///
   /// - Important:
   ///   Quaternions are frequently used to represent 3D transformations. It's
   ///   important to be aware that, when used this way, any quaternion and its

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -273,7 +273,7 @@ extension Quaternion {
   ///
   /// See also:
   /// -
-  /// - `.transformCanonicalized`
+  /// - `.canonicalizedTransform`
   @_transparent
   public var canonicalized: Self {
     guard !isZero else { return .zero }
@@ -298,7 +298,7 @@ extension Quaternion {
   /// -
   /// - `.canonicalized`
   @_transparent
-  public var transformCanonicalized: Self {
+  public var canonicalizedTransform: Self {
     var canonical = canonicalized
     if canonical.real.sign == .plus { return canonical }
     // Clear the signbit of real even for -0
@@ -450,7 +450,7 @@ extension Quaternion: Hashable {
     // (while unfortunately producing some collisions for people who are not,
     // but not in too catastrophic of a fashion).
     if isFinite {
-      transformCanonicalized.components.hash(into: &hasher)
+      canonicalizedTransform.components.hash(into: &hasher)
     } else {
       hasher.combine(RealType.infinity)
     }

--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -446,18 +446,13 @@ extension Quaternion: Hashable {
     // representation. The correct behavior for zero falls out for free from
     // the hash behavior of floating-point, but we need to use a
     // representative member for any non-finite values.
-    // For any values not zero and infinity we use a canonical form, so
-    // that q and -q hash to the same value. This allows people who are using
+    // For any normal values we use the "canonical transform" representation,
+    // where real is always non-negative. This allows people who are using
     // quaternions as rotations to get the expected semantics out of collections
     // (while unfortunately producing some collisions for people who are not,
     // but not in too catastrophic of a fashion).
     if isFinite {
-      let absolute = SIMD4(
-        x: abs(components[0]),
-        y: abs(components[1]),
-        z: abs(components[2]),
-        w: abs(components[3]))
-      absolute.hash(into: &hasher)
+      transformCanonicalized.hash(into: &hasher)
     } else {
       hasher.combine(RealType.infinity)
     }

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -102,27 +102,35 @@ final class PropertyTests: XCTestCase {
     }
     // Validate that all *normal* values hash their absolute components, so
     // that rotations in *R³* of `q` and `-q` will hash to same value.
-    let pis = [
-      Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi,  .pi),
-      Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi,  .pi),
-      Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi,  .pi),
-      Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi, -.pi),
-      Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi,  .pi),
-      Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi, -.pi),
-      Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi),
-      Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi, -.pi),
-
-      Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi,  .pi),
-      Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi),
-      Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi,  .pi),
-      Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi, -.pi),
-      Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi,  .pi),
-      Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi, -.pi),
-      Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi, -.pi),
-      Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi, -.pi),
+    let pairs: [(lhs: Quaternion<T>, rhs: Quaternion<T>)] = [
+      (
+        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi,  .pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi,  .pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi,  .pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi, -.pi)
+      )
     ]
-    for pi in pis[1...] {
-      XCTAssertEqual(pis[0].hashValue, pi.hashValue)
+    for pair in pairs {
+      XCTAssertEqual(pair.lhs.hashValue, pair.rhs.hashValue)
     }
   }
 
@@ -131,21 +139,18 @@ final class PropertyTests: XCTestCase {
     testEquatableHashable(Float64.self)
   }
 
-  func testRotationEquals<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testTransformationEquals<T: Real & SIMDScalar>(_ type: T.Type) {
     let rotations: [(lhs: Quaternion<T>, rhs: Quaternion<T>)] = [
       (
         Quaternion<T>(real:  -.pi, imaginary:  -.pi,  -.pi,  -.pi),
         Quaternion<T>(real:   .pi, imaginary:   .pi,   .pi,   .pi)
-      ),
-      (
+      ), (
         Quaternion<T>(real:   .ulpOfOne, imaginary:   .ulpOfOne,   .ulpOfOne,   .ulpOfOne),
         Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
-      ),
-      (
+      ), (
         Quaternion<T>(real:   .pi, imaginary:  -.pi,   .pi,  -.pi),
         Quaternion<T>(real:  -.pi, imaginary:   .pi,  -.pi,   .pi)
-      ),
-      (
+      ), (
         Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,   .ulpOfOne,   .ulpOfOne),
         Quaternion<T>(real:   .ulpOfOne, imaginary:   .ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
       ),
@@ -154,8 +159,7 @@ final class PropertyTests: XCTestCase {
       (
          Quaternion<T>.zero,
         -Quaternion<T>.zero
-      ),
-      (
+      ), (
         -Quaternion<T>.infinity,
          Quaternion<T>.infinity
       ),
@@ -165,9 +169,9 @@ final class PropertyTests: XCTestCase {
     }
   }
 
-  func testRotationEquals() {
-    testRotationEquals(Float32.self)
-    testRotationEquals(Float64.self)
+  func testTransformationEquals() {
+    testTransformationEquals(Float32.self)
+    testTransformationEquals(Float64.self)
   }
 
   func testCodable<T: Real & SIMDScalar>(_ type: T.Type) throws {

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -165,7 +165,26 @@ final class PropertyTests: XCTestCase {
       ),
     ]
     for (lhs, rhs) in rotations {
-      XCTAssertTrue(lhs.transformEquals(rhs))
+      XCTAssertTrue(lhs.equals(as3DTransform: rhs))
+    }
+
+    let signDifferentAxis: [(lhs: Quaternion<T>, rhs: Quaternion<T>)] = [
+      (
+        Quaternion<T>(real:  -.pi, imaginary:  -.pi,  -.pi,  -.pi),
+        Quaternion<T>(real:  -.pi, imaginary:   .pi,   .pi,   .pi)
+      ), (
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:   .ulpOfOne,   .ulpOfOne,   .ulpOfOne),
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
+      ), (
+        Quaternion<T>(real:  -.pi, imaginary:  -.pi,   .pi,  -.pi),
+        Quaternion<T>(real:  -.pi, imaginary:   .pi,  -.pi,   .pi)
+      ), (
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,   .ulpOfOne,   .ulpOfOne),
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:   .ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
+      )
+    ]
+    for (lhs, rhs) in signDifferentAxis {
+      XCTAssertFalse(lhs.equals(as3DTransform: rhs))
     }
   }
 

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -100,11 +100,74 @@ final class PropertyTests: XCTestCase {
       XCTAssertEqual(infs[0], i)
       XCTAssertEqual(infs[0].hashValue, i.hashValue)
     }
+    // Validate that all *normal* values hash their absolute components, so
+    // that rotations in *R³* of `q` and `-q` will hash to same value.
+    let pis = [
+      Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi,  .pi),
+      Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi,  .pi),
+      Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi,  .pi),
+      Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi, -.pi),
+      Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi,  .pi),
+      Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi, -.pi),
+      Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi),
+      Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi, -.pi),
+
+      Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi,  .pi),
+      Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi),
+      Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi,  .pi),
+      Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi, -.pi),
+      Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi,  .pi),
+      Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi, -.pi),
+      Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi, -.pi),
+      Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi, -.pi),
+    ]
+    for pi in pis[1...] {
+      XCTAssertEqual(pis[0].hashValue, pi.hashValue)
+    }
   }
 
   func testEquatableHashable() {
     testEquatableHashable(Float32.self)
     testEquatableHashable(Float64.self)
+  }
+
+  func testRotationEquals<T: Real & SIMDScalar>(_ type: T.Type) {
+    let rotations: [(lhs: Quaternion<T>, rhs: Quaternion<T>)] = [
+      (
+        Quaternion<T>(real:  -.pi, imaginary:  -.pi,  -.pi,  -.pi),
+        Quaternion<T>(real:   .pi, imaginary:   .pi,   .pi,   .pi)
+      ),
+      (
+        Quaternion<T>(real:   .ulpOfOne, imaginary:   .ulpOfOne,   .ulpOfOne,   .ulpOfOne),
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
+      ),
+      (
+        Quaternion<T>(real:   .pi, imaginary:  -.pi,   .pi,  -.pi),
+        Quaternion<T>(real:  -.pi, imaginary:   .pi,  -.pi,   .pi)
+      ),
+      (
+        Quaternion<T>(real:  -.ulpOfOne, imaginary:  -.ulpOfOne,   .ulpOfOne,   .ulpOfOne),
+        Quaternion<T>(real:   .ulpOfOne, imaginary:   .ulpOfOne,  -.ulpOfOne,  -.ulpOfOne)
+      ),
+
+      // Zero and infinity must have equal rotations too
+      (
+         Quaternion<T>.zero,
+        -Quaternion<T>.zero
+      ),
+      (
+        -Quaternion<T>.infinity,
+         Quaternion<T>.infinity
+      ),
+    ]
+    for (lhs, rhs) in rotations {
+      XCTAssertTrue(lhs.rotationEquals(rhs))
+    }
+  }
+
+  func testRotationEquals() {
+    testRotationEquals(Float32.self)
+    testRotationEquals(Float64.self)
   }
 
   func testCodable<T: Real & SIMDScalar>(_ type: T.Type) throws {

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -161,7 +161,7 @@ final class PropertyTests: XCTestCase {
       ),
     ]
     for (lhs, rhs) in rotations {
-      XCTAssertTrue(lhs.rotationEquals(rhs))
+      XCTAssertTrue(lhs.transformEquals(rhs))
     }
   }
 

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -104,28 +104,28 @@ final class PropertyTests: XCTestCase {
     // that rotations in *R³* of `q` and `-q` will hash to same value.
     let pairs: [(lhs: Quaternion<T>, rhs: Quaternion<T>)] = [
       (
-        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi,  .pi),
-        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi,  .pi)
+        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi,  .pi),
+        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi, -.pi)
       ), (
         Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi,  .pi),
-        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi)
-      ), (
-        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi,  .pi),
-        Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi,  .pi)
-      ), (
-        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi, -.pi),
-        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi, -.pi)
-      ), (
-        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi,  .pi),
-        Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi,  .pi)
-      ), (
-        Quaternion<T>(real:  .pi, imaginary: -.pi,  .pi, -.pi),
-        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi, -.pi)
-      ), (
-        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi),
         Quaternion<T>(real: -.pi, imaginary:  .pi, -.pi, -.pi)
       ), (
-        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi, -.pi),
+        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi,  .pi)
+      ), (
+        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi),
+        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary: -.pi, -.pi,  .pi),
+        Quaternion<T>(real: -.pi, imaginary:  .pi,  .pi, -.pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi, -.pi, -.pi),
+        Quaternion<T>(real: -.pi, imaginary: -.pi,  .pi,  .pi)
+      ), (
+        Quaternion<T>(real:  .pi, imaginary:  .pi,  .pi,  .pi),
         Quaternion<T>(real: -.pi, imaginary: -.pi, -.pi, -.pi)
       )
     ]


### PR DESCRIPTION
- **Canonical Representations**
Add `canonicalized` and `canonicalizedTransform` properties

- **Equatable**
Update type and header documentation and mention the alternative for transformations in *R³*

- **Hashable**
This PR changes the hashing behavior of `Quaternion`, so that any *finite* quaternion `q` clears the sign bit of its real component before hashing.

- **Transform Equality**
Added a new `transformEquals()` method on `Quaternion` to test for 3D transformation equality.