### PR TITLE
Add transformation operations to Quaternion

### DIFF
--- a/Sources/QuaternionModule/Transformation.md
+++ b/Sources/QuaternionModule/Transformation.md
@@ -1,10 +1,18 @@
 # Transformation
 
-`Rotation.swift` encapsulates an API for working with other forms of rotation representations, such as *Angle/Axis*, *Polar* or *Rotation Vector*. The API provides conversion from these representations to `Quaternion` and vice versa. Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.
+`Transformation.swift` encapsulates an API for working with other representations of transformations, such as *Angle-Axis*, *Polar* and *Rotation Vector*. The API provides operations to convert from these representations to `Quaternion` and vice versa.  
+Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.
 
 ## Policies
- - zero and non-finite quaternions have an indeterminate angle and axis. Thus,
-   the `angle` property of `.zero` or `.infinity` is `RealType.nan`, and the
-   `axis` property of `.zero` or `.infinity` is `.nan` in all lanes.
- - Quaternions with `angle == .zero` have an indeterminate axis. Thus, the
-   `axis` property is `.nan` in all lanes.
+
+- zero and non-finite quaternions have indeterminate transformation properties and can not be converted to another representation. Thus, 
+  
+    - The `angle` property of `.zero` or `.infinity` is `RealType.nan`. 
+    - The `axis` property of `.zero` or `.infinity` is `RealType.nan` in all lanes.
+    - The `rotationVector` property of `.zero` or `.infinity` is `RealType.nan` in all lanes.
+
+- Quaternions with `angle == .zero` have an indeterminate axis. Thus,
+
+    - the `axis` property of `angle == .zero` is `RealType.nan` in all lanes.
+    - the `rotationVector` property of `angle == .zero` is `RealType.nan` in all lanes.
+

--- a/Sources/QuaternionModule/Transformation.md
+++ b/Sources/QuaternionModule/Transformation.md
@@ -1,23 +1,25 @@
 # Transformation
 
-`Transformation.swift` encapsulates an API for working with other representations of transformations, such as [*Angle-Axis*][angle_axis_wiki], [*Polar*][polar_wiki] and [*Rotation Vector*][rotation_vector_wiki]. The API provides operations to convert from these representations to `Quaternion` and vice versa.  
-Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.
+In computer science, quaternions are frequently used to represent three-dimensional rotations; as quaternions have some [advantages over other representations][advantages].
+
+`Transformation.swift` encapsulates an API to interact with the three-dimensional transformation properties of quaternions. It provides conversions to and from other rotation representations, namely [*Angle-Axis*][angle_axis_wiki], [*Rotation Vector*][rotation_vector_wiki] and [*Polar decomposition*][polar_wiki], as well as it provides methods to directly transform arbitrary vectors by quaternions.
 
 ## Policies
 
-- zero and non-finite quaternions have indeterminate transformation properties and can not be converted to another representation. Thus, 
+- zero and non-finite quaternions have indeterminate transformation properties and can not be converted to other representations. Thus, 
   
-    - The `angle` property of `.zero` or `.infinity` is `RealType.nan`. 
-    - The `axis` property of `.zero` or `.infinity` is `RealType.nan` in all lanes.
-    - The `rotationVector` property of `.zero` or `.infinity` is `RealType.nan` in all lanes.
+    - The `angle` of `.zero` or `.infinity` is `RealType.nan`. 
+    - The `axis` of `.zero` or `.infinity` is `RealType.nan` in all lanes.
+    - The `rotationVector` of `.zero` or `.infinity` is `RealType.nan` in all lanes.
+		- The polar `phase` of `.zero` or `.infinity` is `RealType.nan`
 
-- Quaternions with `angle == .zero` have an indeterminate axis. Thus,
+- Quaternions with an `angle` of `.zero` have an indeterminate rotation axis. Thus,
 
-    - the `axis` property of `angle == .zero` is `RealType.nan` in all lanes.
-    - the `rotationVector` property of `angle == .zero` is `RealType.nan` in all lanes.
+    - the `axis` of `angle == .zero` is `RealType.nan` in all lanes.
+    - the `rotationVector` of `angle == .zero` is `RealType.nan` in all lanes.
 
 
+[advantages]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Advantages_of_quaternions
 [angle_axis_wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
 [polar_wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
 [rotation_vector_wiki]: https://en.wikipedia.org/wiki/Axis–angle_representation#Rotation_vector
-

--- a/Sources/QuaternionModule/Transformation.md
+++ b/Sources/QuaternionModule/Transformation.md
@@ -1,0 +1,10 @@
+# Transformation
+
+`Rotation.swift` encapsulates an API for working with other forms of rotation representations, such as *Angle/Axis*, *Polar* or *Rotation Vector*. The API provides conversion from these representations to `Quaternion` and vice versa. Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.
+
+## Policies
+ - zero and non-finite quaternions have an indeterminate angle and axis. Thus,
+   the `angle` property of `.zero` or `.infinity` is `RealType.nan`, and the
+   `axis` property of `.zero` or `.infinity` is `.nan` in all lanes.
+ - Quaternions with `angle == .zero` have an indeterminate axis. Thus, the
+   `axis` property is `.nan` in all lanes.

--- a/Sources/QuaternionModule/Transformation.md
+++ b/Sources/QuaternionModule/Transformation.md
@@ -1,6 +1,6 @@
 # Transformation
 
-`Transformation.swift` encapsulates an API for working with other representations of transformations, such as *Angle-Axis*, *Polar* and *Rotation Vector*. The API provides operations to convert from these representations to `Quaternion` and vice versa.  
+`Transformation.swift` encapsulates an API for working with other representations of transformations, such as [*Angle-Axis*][angle_axis_wiki], [*Polar*][polar_wiki] and [*Rotation Vector*][rotation_vector_wiki]. The API provides operations to convert from these representations to `Quaternion` and vice versa.  
 Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.
 
 ## Policies
@@ -15,4 +15,9 @@ Additionally, the API provides a method to directly rotate an arbitrary vector b
 
     - the `axis` property of `angle == .zero` is `RealType.nan` in all lanes.
     - the `rotationVector` property of `angle == .zero` is `RealType.nan` in all lanes.
+
+
+[angle_axis_wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
+[polar_wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
+[rotation_vector_wiki]: https://en.wikipedia.org/wiki/Axis–angle_representation#Rotation_vector
 

--- a/Sources/QuaternionModule/Transformation.swift
+++ b/Sources/QuaternionModule/Transformation.swift
@@ -121,8 +121,8 @@ extension Quaternion {
 
   /// The [polar decomposition][wiki].
   ///
-  /// Returns the length of this quaternion, half rotation angle in radians of
-  /// *[0, π]* range and the rotation axis as SIMD3 vector of unit length.
+  /// Returns the length of this quaternion, phase in radians of range *[0, π]*
+  /// and the rotation axis as SIMD3 vector of unit length.
   ///
   /// Edge cases:
   /// -
@@ -144,7 +144,7 @@ extension Quaternion {
   /// - `init(rotation:)`
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
-  public var polar: (length: RealType, halfAngle: RealType, axis: SIMD3<RealType>) {
+  public var polar: (length: RealType, phase: RealType, axis: SIMD3<RealType>) {
     (length, halfAngle, axis)
   }
 
@@ -257,11 +257,11 @@ extension Quaternion {
 
   /// Creates a quaternion specified with [polar coordinates][wiki].
   ///
-  /// This initializer reads given `length`, `halfAngle` and `axis` values and
+  /// This initializer reads given `length`, `phase` and `axis` values and
   /// creates a quaternion of equal rotation properties and specified *length*
   /// using the following equation:
   ///
-  ///     Q = (cos(halfAngle), axis * sin(halfAngle)) * length
+  ///     Q = (cos(phase), axis * sin(phase)) * length
   ///
   /// Given `axis` gets normalized if it is not of unit length.
   ///
@@ -293,11 +293,11 @@ extension Quaternion {
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
   @inlinable
-  public init(length: RealType, halfAngle: RealType, axis: SIMD3<RealType>) {
+  public init(length: RealType, phase: RealType, axis: SIMD3<RealType>) {
     let axisLength: RealType = .sqrt(axis.lengthSquared)
-    if halfAngle.isFinite && axisLength.isNormal {
+    if phase.isFinite && axisLength.isNormal {
       self = Quaternion(
-        halfAngle: halfAngle,
+        halfAngle: phase,
         unitAxis: axis/axisLength
       ).multiplied(by: length)
     } else {

--- a/Sources/QuaternionModule/Transformation.swift
+++ b/Sources/QuaternionModule/Transformation.swift
@@ -443,7 +443,7 @@ extension Quaternion {
   ///   - unitAxis: The rotation axis of unit length
   @usableFromInline @inline(__always)
   internal init(halfAngle: RealType, unitAxis: SIMD3<RealType>) {
-    self.init(.cos(halfAngle), unitAxis * .sin(halfAngle))
+    self.init(real: .cos(halfAngle), imaginary: unitAxis * .sin(halfAngle))
   }
 }
 

--- a/Sources/QuaternionModule/Transformation.swift
+++ b/Sources/QuaternionModule/Transformation.swift
@@ -309,24 +309,40 @@ extension Quaternion {
     }
   }
 
-  /// Rotates given vector by this quaternion.
+  /// Transforms a vector by this quaternion.
   ///
-  /// As quaternions can be used to represent three-dimensional rotations, it is
-  /// is possible to also rotate a three-dimensional vector by a quaternion. The
-  /// rotation of an arbitrary vector by a quaternion is known as an action.
+  /// Quaternions are frequently used to represent three-dimensional
+  /// transformations, and thus are used to transform vectors in
+  /// three-dimensional space. The transformation of an arbitrary vector
+  /// by a quaternion is known as an action.
+  ///
+  /// The canonical way of transforming an arbitrary three-dimensional vector
+  /// `v` by a quaternion `q` is given by the following [formula][wiki]
+  ///
+  ///     p' = qpq⁻¹
+  ///
+  /// where `p` is a *pure* quaternion (`real == .zero`) with imaginary part equal
+  /// to vector `v`, and where `p'` is another pure quaternion with imaginary
+  /// part equal to the transformed vector `v'`. The implementation uses this
+  /// formular but boils down to a simpler and faster implementation as `p` is
+  /// known to be pure and `q` is assumed to have unit length – which allows
+  /// simplification.
   ///
   /// - Note: This method assumes this quaternion is of unit length.
   ///
   /// Edge cases:
   /// -
-  /// - If `vector` is `.infinity` in any of the lanes or all, the returning
+  /// - For any quaternion `q`, even `.zero` or `.infinity`, if `vector` is
+  /// `.infinity` or `-.infinity` in any of the lanes or all, the returning
   /// vector is `.infinity` in all lanes:
   ///   ```
-  ///   Quaternion(rotation: .zero) == .zero
+  ///   SIMD3(-.infinity,0,0) * q == SIMD3(.infinity,.infinity,.infinity)
   ///   ```
   ///
   /// - Parameter vector: A vector to rotate by this quaternion
   /// - Returns: The vector rotated by this quaternion
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Using_quaternion_as_rotations
   @inlinable
   public func act(on vector: SIMD3<RealType>) -> SIMD3<RealType> {
     guard vector.isFinite else { return SIMD3(repeating: .infinity) }

--- a/Sources/QuaternionModule/Transformation.swift
+++ b/Sources/QuaternionModule/Transformation.swift
@@ -1,0 +1,369 @@
+//===--- Transformation.swift ---------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Quaternion {
+  /// The [rotation angle][wiki] of the Angle-Axis representation.
+  ///
+  /// Returns the rotation angle about the rotation *axis* in radians
+  /// within *[0, 2π]* range.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If the quaternion is zero or non-finite, angle is `nan`.
+  ///
+  /// See also:
+  /// -
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `.polar`
+  /// - `.rotationVector`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
+  @inlinable
+  public var angle: RealType {
+    2 * halfAngle
+  }
+
+  /// The [rotation axis][wiki] of the Angle-Axis representation.
+  ///
+  /// Returns the *(x,y,z)* rotation axis encoded in the quaternion
+  /// as SIMD3 vector of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If the quaternion is zero or non-finite, axis is `nan` in all lanes.
+  /// - If the rotation angle is zero, axis is `nan` in all lanes.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.angleAxis`
+  /// - `.polar`
+  /// - `.rotationVector`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
+  @inlinable
+  public var axis: SIMD3<RealType> {
+    guard isFinite && imaginary != .zero && !real.isZero else {
+      return SIMD3(repeating: .nan)
+    }
+    return imaginary / .sqrt(imaginary.lengthSquared)
+  }
+
+  /// The [Angle-Axis][wiki] representation.
+  ///
+  /// Returns the rotation angle in radians within *[0, 2π]* and the rotation
+  /// axis as SIMD3 vector of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If the quaternion is zero or non-finite, angle and axis are `nan`.
+  /// - If the angle is zero, axis is `nan` in all lanes.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.polar`
+  /// - `.rotationVector`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
+  public var angleAxis: (angle: RealType, axis: SIMD3<RealType>) {
+    (angle, axis)
+  }
+
+  /// The [rotation vector][rotvector].
+  ///
+  /// A rotation vector is a vector of same direction as the rotation axis,
+  /// whose length is the rotation angle of an Angle-Axis representation. It
+  /// is effectively the product of multiplying the rotation `axis` by the
+  /// rotation `angle`. Rotation vectors are often called "scaled axis" — this
+  /// is a different name for the same concept.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If the quaternion is zero or non-finite, the rotation vector is `nan`
+  /// in all lanes.
+  /// - If the rotation angle is zero, the rotation vector is `nan`
+  /// in all lanes.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [rotvector]: https://en.wikipedia.org/wiki/Axis–angle_representation#Rotation_vector
+  @_transparent
+  public var rotationVector: SIMD3<RealType> {
+    axis * angle
+  }
+
+  /// The [polar decomposition][wiki].
+  ///
+  /// Returns the length of this quaternion, half rotation angle in radians of
+  /// *[0, π]* range and the rotation axis as SIMD3 vector of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If the quaternion is zero, length is `.zero` and angle and axis
+  /// are `nan`.
+  /// - If the quaternion is non-finite, length is `.infinity` and angle and
+  /// axis are `nan`.
+  /// - For any length other than `.zero` or `.infinity`, if angle is zero, axis
+  /// is `nan`.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `.rotationVector`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
+  public var polar: (length: RealType, halfAngle: RealType, axis: SIMD3<RealType>) {
+    (length, halfAngle, axis)
+  }
+
+  /// Creates a unit quaternion specified with [Angle-Axis][wiki] values.
+  ///
+  /// Angle-Axis is a representation of a 3D rotation using two different
+  /// quantities: an angle describing the magnitude of rotation, and a vector
+  /// of unit length indicating the axis direction to rotate along.
+  ///
+  /// This initializer reads given `angle` and `axis` values and creates a
+  /// quaternion of equal rotation properties using the following equation:
+  ///
+  ///     Q = (cos(angle/2), axis * sin(angle/2))
+  ///
+  /// Given `axis` gets normalized if it is not of unit length.
+  ///
+  /// The final quaternion is of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - For any `θ`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Quaternion(angle: θ, axis: .zero) == .zero
+  ///   ```
+  /// - For any `θ`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Quaternion(angle: θ, axis: .infinity) == .ininfity
+  ///   ```
+  /// - Otherwise, `θ` must be finite, or a precondition failure occurs.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `.rotationVector`
+  /// - `.polar`
+  /// - `init(rotation:)`
+  /// - `init(length:angle:axis)`
+  ///
+  /// - Parameter angle: The rotation angle about the rotation axis in radians
+  /// - Parameter axis: The rotation axis
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
+  @inlinable
+  public init(angle: RealType, axis: SIMD3<RealType>) {
+    let length: RealType = .sqrt(axis.lengthSquared)
+    if angle.isFinite && length.isNormal {
+      self = Quaternion(halfAngle: angle/2, unitAxis: axis/length)
+    } else {
+      precondition(
+        length.isZero || length.isInfinite,
+        "Either angle must be finite, or axis length must be zero or infinite."
+      )
+      self = Quaternion(length)
+    }
+  }
+
+  /// Creates a unit quaternion specified with given [rotation vector][wiki].
+  ///
+  /// A rotation vector is a vector of same direction as the rotation axis,
+  /// whose length is the rotation angle of an Angle-Axis representation. It
+  /// is effectively the product of multiplying the rotation `axis` by the
+  /// rotation `angle`.
+  ///
+  /// This initializer reads the angle and axis values of given rotation vector
+  /// and creates a quaternion of equal rotation properties using the following
+  /// equation:
+  ///
+  ///     Q = (cos(angle/2), axis * sin(angle/2))
+  ///
+  /// Rotation vectors are sometimes referred to as *scaled axis* — this is a
+  /// different name for the same concept.
+  ///
+  /// The final quaternion is of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - If `vector` is `.zero`, the quaternion is `.zero`:
+  ///   ```
+  ///   Quaternion(rotation: .zero) == .zero
+  ///   ```
+  /// - If `vector` is `.infinity` or `-.infinity`, the quaternion is `.infinity`:
+  ///   ```
+  ///   Quaternion(rotation: -.infinity) == .infinity
+  ///   ```
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `.polar`
+  /// - `.rotationVector`
+  /// - `init(angle:axis:)`
+  /// - `init(length:angle:axis)`
+  ///
+  /// - Parameter vector: The rotation vector.
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Axis–angle_representation#Rotation_vector
+  @inlinable
+  public init(rotation vector: SIMD3<RealType>) {
+    let angle: RealType = .sqrt(vector.lengthSquared)
+    if !angle.isZero && angle.isFinite {
+      self = Quaternion(halfAngle: angle/2, unitAxis: vector/angle)
+    } else {
+      self = Quaternion(angle)
+    }
+  }
+
+  /// Creates a quaternion specified with [polar coordinates][wiki].
+  ///
+  /// This initializer reads given `length`, `halfAngle` and `axis` values and
+  /// creates a quaternion of equal rotation properties and specified *length*
+  /// using the following equation:
+  ///
+  ///     Q = (cos(halfAngle), axis * sin(halfAngle)) * length
+  ///
+  /// Given `axis` gets normalized if it is not of unit length.
+  ///
+  /// Edge cases:
+  /// -
+  /// - Negative lengths are interpreted as reflecting the point through the origin, i.e.:
+  ///   ```
+  ///   Quaternion(length: -r, angle: θ, axis: axis) == Quaternion(length: -r, angle: θ, axis: axis)
+  ///   ```
+  /// - For any `θ` and any `axis`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Quaternion(length: .zero, angle: θ, axis: axis) == .zero
+  ///   ```
+  /// - For any `θ` and any `axis`, even `.infinity` or `.nan`:
+  ///   ```
+  ///   Quaternion(length: .infinity, angle: θ, axis: axis) == .infinity
+  ///   ```
+  /// - Otherwise, `θ` and `axis` must be finite, or a precondition failure occurs.
+  ///
+  /// See also:
+  /// -
+  /// - `.angle`
+  /// - `.axis`
+  /// - `.angleAxis`
+  /// - `.rotationVector`
+  /// - `.polar`
+  /// - `init(angle:axis)`
+  /// - `init(rotation:)`
+  ///
+  /// [wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
+  @inlinable
+  public init(length: RealType, halfAngle: RealType, axis: SIMD3<RealType>) {
+    let axisLength: RealType = .sqrt(axis.lengthSquared)
+    if halfAngle.isFinite && axisLength.isNormal {
+      self = Quaternion(
+        halfAngle: halfAngle,
+        unitAxis: axis/axisLength
+      ).multiplied(by: length)
+    } else {
+      precondition(
+        length.isZero || length.isInfinite,
+        "Either angle must be finite, or length must be zero or infinite."
+      )
+      self = Quaternion(length)
+    }
+  }
+}
+
+// MARK: - Transformation Helper
+//
+// While Angle/Axis, Rotation Vector and Polar are different representations
+// of transformations, they have common properties such as being based on a
+// rotation *angle* about a rotation axis of unit length.
+//
+// The following extension provides these common operation internally.
+extension Quaternion {
+  /// The half rotation angle in radians within *[0, π]* range.
+  ///
+  /// Edge cases:
+  /// -
+  /// If the quaternion is zero or non-finite, halfAngle is `nan`.
+  @usableFromInline @inline(__always)
+  internal var halfAngle: RealType {
+    guard !isZero && isFinite else { return .nan }
+    return .atan2(y: .sqrt(imaginary.lengthSquared), x: real)
+  }
+
+  /// Creates a new quaternion from given half rotation angle about given
+  /// rotation axis.
+  ///
+  /// The angle-axis values are transformed using the following equation:
+  ///
+  ///     Q = (cos(halfAngle), unitAxis * sin(halfAngle))
+  ///
+  /// - Parameters:
+  ///   - halfAngle: The half rotation angle
+  ///   - unitAxis: The rotation axis of unit length
+  @usableFromInline @inline(__always)
+  internal init(halfAngle: RealType, unitAxis: SIMD3<RealType>) {
+    self.init(.cos(halfAngle), unitAxis * .sin(halfAngle))
+  }
+}
+
+// MARK: - SIMD Helper
+//
+// Provides common vector operations on SIMD3 to ease the use of "imaginary"
+// and *(x,y,z)* axis representations internally to the module.
+extension SIMD3 where Scalar: FloatingPoint {
+
+  /// Returns the squared length of this SIMD3 instance.
+  @usableFromInline @inline(__always)
+  internal var lengthSquared: Scalar {
+    (self * self).sum()
+  }
+
+  /// Returns the vector/cross product of this quaternion with `other`.
+  @usableFromInline @inline(__always)
+  internal func vectorProduct(with other: SIMD3<Scalar>) -> SIMD3<Scalar> {
+    let selfYZW = self[SIMD3<Int>(1,2,0)]
+    let otherYZX = other[SIMD3<Int>(1,2,0)]
+    let selfZXY = self[SIMD3<Int>(2,0,1)]
+    let otherZXY = other[SIMD3<Int>(2,0,1)]
+    return (selfYZW * otherZXY) - (selfZXY * otherYZX)
+  }
+}

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -237,15 +237,15 @@ final class TransformationTests: XCTestCase {
       let vrot = (q                     // q
         * Quaternion(imaginary: vector) // v   (pure quaternion)
         * q.conjugate                   // q⁻¹ (as q is of unit length, q⁻¹ == q*)
-      ).imaginary // the result is pure quaternion with v' == imaginary
+      ).imaginary // the result is a pure quaternion with v' == imaginary
 
       XCTAssertTrue(q.act(on: vector).x.isFinite)
       XCTAssertTrue(q.act(on: vector).y.isFinite)
       XCTAssertTrue(q.act(on: vector).z.isFinite)
       // Test for sign equality on the components to see if the vector rotated
-      // to the correct quadrant and if the vector is of equal in length,
-      // instead of testing component equality – as they are hard to compare
-      // with proper tolerance
+      // to the correct quadrant and if the vector is of equal length, instead
+      // of testing component equality – as they are hard to compare with
+      // proper tolerance
       XCTAssertEqual(q.act(on: vector).x.sign, vrot.x.sign)
       XCTAssertEqual(q.act(on: vector).y.sign, vrot.y.sign)
       XCTAssertEqual(q.act(on: vector).z.sign, vrot.z.sign)
@@ -274,7 +274,7 @@ final class TransformationTests: XCTestCase {
 
     // An axis perpendicular to the vector, so all lanes are changing equally
     let axis = SIMD3<T>(1/2,0,-1/2)
-    // Create a value close (somewhat) close to .greatestFiniteMagnitude
+    // Create a value (somewhat) close to .greatestFiniteMagnitude
     let scalar = T(
       sign: .plus, exponent: T.greatestFiniteMagnitude.exponent,
       significand: 1.999999

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -117,10 +117,10 @@ final class TransformationTests: XCTestCase {
   }
 
   func testHalfAngleAndAxisOverflow<T: Real & SIMDScalar>(_ type: T.Type) {
-    let unscaled = Quaternion<T>(1, SIMD3(repeating: 1))
+    let unscaled = Quaternion<T>(real: 1, imaginary: .one)
     let scaled = Quaternion<T>(
-      .greatestFiniteMagnitude,
-      SIMD3(repeating: .greatestFiniteMagnitude)
+      real: .greatestFiniteMagnitude,
+      imaginary: SIMD3(repeating: .greatestFiniteMagnitude)
     )
     XCTAssertEqual(scaled.angle, unscaled.angle)
     XCTAssertEqual(scaled.axis, unscaled.axis)
@@ -132,10 +132,10 @@ final class TransformationTests: XCTestCase {
   }
 
   func testHalfAngleAndAxisUnderflow<T: Real & SIMDScalar>(_ type: T.Type) {
-    let unscaled = Quaternion<T>(1, SIMD3(repeating: 1))
+    let unscaled = Quaternion<T>(real: 1, imaginary: .one)
     let scaled = Quaternion<T>(
-      .leastNormalMagnitude,
-      SIMD3(repeating: .leastNormalMagnitude)
+      real: .leastNormalMagnitude,
+      imaginary: SIMD3(repeating: .leastNormalMagnitude)
     )
     XCTAssertEqual(scaled.angle, unscaled.angle)
     XCTAssertEqual(scaled.axis, unscaled.axis)

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -62,53 +62,53 @@ final class TransformationTests: XCTestCase {
 
   func testAngleAxisEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
     // Zero/Zero
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .zero).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .zero).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: .zero), .zero)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .zero, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .zero, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .zero, angle: .zero, axis: .zero), .zero)
     // Inf/Zero
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .zero).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .zero).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: .zero), .zero)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .infinity, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .infinity, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .zero, angle: .infinity, axis: .infinity), .zero)
     // -Inf/Zero
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .zero).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .zero).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: .zero), .zero)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: -.infinity, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: -.infinity, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .zero, angle: -.infinity, axis: -.infinity), .zero)
     // NaN/Zero
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .zero).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .zero).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: .zero), .zero)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .nan, axis: .nan).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .zero, angle: .nan, axis: .nan).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .zero, angle: .nan, axis: .nan), .zero)
     // Zero/Inf
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: .infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .zero, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .zero, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, angle: .zero, axis: .zero), .infinity)
     // Inf/Inf
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: .infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .infinity, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .infinity, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, angle: .infinity, axis: .infinity), .infinity)
     // -Inf/Inf
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: .infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: -.infinity, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: -.infinity, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, angle: -.infinity, axis: -.infinity), .infinity)
     // NaN/Inf
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: .infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .nan, axis: .nan).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: .infinity, angle: .nan, axis: .nan).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, angle: .nan, axis: .nan), .infinity)
     // Zero/-Inf
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: -.infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: -.infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: -.infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .zero, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .zero, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: -.infinity, angle: .zero, axis: .zero), .infinity)
     // Inf/-Inf
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: -.infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: -.infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: -.infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .infinity, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .infinity, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: -.infinity, angle: .infinity, axis: .infinity), .infinity)
     // -Inf/-Inf
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: -.infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: -.infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: -.infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: -.infinity, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: -.infinity, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: -.infinity, angle: -.infinity, axis: -.infinity), .infinity)
     // NaN/-Inf
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: -.infinity).axis.isNaN)
-    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: -.infinity).angle.isNaN)
-    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: -.infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .nan, axis: .nan).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(length: -.infinity, angle: .nan, axis: .nan).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(length: -.infinity, angle: .nan, axis: .nan), .infinity)
   }
 
   func testAngleAxisEdgeCases() {
@@ -151,12 +151,12 @@ final class TransformationTests: XCTestCase {
   func testPolarDecomposition<T: Real & SIMDScalar>(_ type: T.Type) {
     let axis = SIMD3<T>(0,-1,0)
 
-    let q = Quaternion<T>(length: 5, halfAngle: .pi, axis: axis)
+    let q = Quaternion<T>(length: 5, phase: .pi, axis: axis)
     XCTAssertEqual(q.axis, axis)
     XCTAssertEqual(q.angle, .pi * 2)
 
     XCTAssertEqual(q.polar.length, 5)
-    XCTAssertEqual(q.polar.halfAngle, .pi)
+    XCTAssertEqual(q.polar.phase, .pi)
     XCTAssertEqual(q.polar.axis, axis)
   }
 
@@ -166,15 +166,18 @@ final class TransformationTests: XCTestCase {
   }
 
   func testPolarDecompositionEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
-    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle: .infinity, axis:  .infinity), .zero)
-    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle:-.infinity, axis: -.infinity), .zero)
-    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle: .nan     , axis:  .nan     ), .zero)
-    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle: .infinity, axis:  .infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle:-.infinity, axis: -.infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle: .nan     , axis:  .infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle: .infinity, axis:  .infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle:-.infinity, axis: -.infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle: .nan     , axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length: .zero, phase: .zero    , axis:  .zero    ), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .zero, phase: .infinity, axis:  .infinity), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .zero, phase:-.infinity, axis: -.infinity), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .zero, phase: .nan     , axis:  .nan     ), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .zero    , axis:  .zero    ), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .infinity, axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, phase:-.infinity, axis: -.infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .nan     , axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .zero    , axis:  .zero    ), .zero)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .infinity, axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase:-.infinity, axis: -.infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .nan     , axis:  .infinity), .infinity)
   }
 
   func testPolarDecompositionEdgeCases() {
@@ -273,7 +276,7 @@ final class TransformationTests: XCTestCase {
     // is rotate by a perpendicular axis with an angle that is a multiple of π
 
     // An axis perpendicular to the vector, so all lanes are changing equally
-    let axis = SIMD3<T>(1/2,0,-1/2)
+    let axis = SIMD3<T>(1,0,-1) / .sqrt(2)
     // Create a value (somewhat) close to .greatestFiniteMagnitude
     let scalar = T(
       sign: .plus, exponent: T.greatestFiniteMagnitude.exponent,

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -344,9 +344,9 @@ final class TransformationTests: XCTestCase {
     // Perform a 180° rotation on all components
     let pi = Quaternion(angle: .pi, axis: axis).act(on: closeToZero)
     // Must be finite after the rotation
-    XCTAssertTrue(pi.x.isFinite)
-    XCTAssertTrue(pi.y.isFinite)
-    XCTAssertTrue(pi.z.isFinite)
+    XCTAssertTrue(!pi.x.isZero)
+    XCTAssertTrue(!pi.y.isZero)
+    XCTAssertTrue(!pi.z.isZero)
     XCTAssertTrue(closeEnough(pi.x, -scalar, ulps: 2))
     XCTAssertTrue(closeEnough(pi.y, -scalar, ulps: 2))
     XCTAssertTrue(closeEnough(pi.z, -scalar, ulps: 2))

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -1,0 +1,195 @@
+//===--- PolarTests.swift -------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import RealModule
+
+@testable import QuaternionModule
+
+final class TransformationTests: XCTestCase {
+
+  // MARK: Angle/Axis
+
+  func testAngleAxisSpin<T: Real & SIMDScalar>(_ type: T.Type) {
+    let xAxis = SIMD3<T>(1,0,0)
+    // Positive angle, positive axis
+    XCTAssertEqual(Quaternion<T>(angle: .pi, axis: xAxis).angle, .pi)
+    XCTAssertEqual(Quaternion<T>(angle: .pi, axis: xAxis).axis, xAxis)
+    // Negative angle, positive axis
+    XCTAssertEqual(Quaternion<T>(angle: -.pi, axis: xAxis).angle, .pi)
+    XCTAssertEqual(Quaternion<T>(angle: -.pi, axis: xAxis).axis, -xAxis)
+    // Positive angle, negative axis
+    XCTAssertEqual(Quaternion<T>(angle: .pi, axis: -xAxis).angle, .pi)
+    XCTAssertEqual(Quaternion<T>(angle: .pi, axis: -xAxis).axis, -xAxis)
+    // Negative angle, negative axis
+    XCTAssertEqual(Quaternion<T>.init(angle: -.pi, axis: -xAxis).angle, .pi)
+    XCTAssertEqual(Quaternion<T>.init(angle: -.pi, axis: -xAxis).axis, xAxis)
+  }
+
+  func testAngleAxisSpin() {
+    testAngleAxisSpin(Float32.self)
+    testAngleAxisSpin(Float64.self)
+  }
+
+  func testAngleMultipleOfPi<T: Real & SIMDScalar>(_ type: T.Type) {
+    let xAxis = SIMD3<T>(1,0,0)
+    // 2π
+    let pi2 = Quaternion<T>(angle: .pi * 2, axis: xAxis)
+    XCTAssertEqual(pi2.angle, .pi * 2)
+    XCTAssertEqual(pi2.axis, xAxis)
+    // 3π - axis inverted
+    let pi3 = Quaternion<T>(angle: .pi * 3, axis: xAxis)
+    XCTAssertEqual(pi3.angle, .pi, accuracy: .ulpOfOne * 2)
+    XCTAssertEqual(pi3.axis, -xAxis)
+    // 4π - axis inverted
+    let pi4 = Quaternion<T>(angle: .pi * 4, axis: xAxis)
+    XCTAssertEqual(pi4.angle, .zero, accuracy: .ulpOfOne * 6)
+    XCTAssertEqual(pi4.axis, -xAxis)
+    // 5π - axis restored
+    let pi5 = Quaternion<T>(angle: .pi * 5, axis: xAxis)
+    XCTAssertEqual(pi5.angle, .pi, accuracy: .ulpOfOne * 10)
+    XCTAssertEqual(pi5.axis, xAxis)
+  }
+
+  func testAngleMultipleOfPi() {
+    testAngleMultipleOfPi(Float32.self)
+    testAngleMultipleOfPi(Float64.self)
+  }
+
+  func testAngleAxisEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
+    // Zero/Zero
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: .zero), .zero)
+    // Inf/Zero
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: .zero), .zero)
+    // -Inf/Zero
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: .zero), .zero)
+    // NaN/Zero
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .zero).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .zero).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: .zero), .zero)
+    // Zero/Inf
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: .infinity), .infinity)
+    // Inf/Inf
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: .infinity), .infinity)
+    // -Inf/Inf
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: .infinity), .infinity)
+    // NaN/Inf
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: .infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: .infinity), .infinity)
+    // Zero/-Inf
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .zero, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .zero, axis: -.infinity), .infinity)
+    // Inf/-Inf
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .infinity, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .infinity, axis: -.infinity), .infinity)
+    // -Inf/-Inf
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: -.infinity, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: -.infinity, axis: -.infinity), .infinity)
+    // NaN/-Inf
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: -.infinity).axis.isNaN)
+    XCTAssertTrue(Quaternion<T>(angle: .nan, axis: -.infinity).angle.isNaN)
+    XCTAssertEqual(Quaternion<T>(angle: .nan, axis: -.infinity), .infinity)
+  }
+
+  func testAngleAxisEdgeCases() {
+    testAngleAxisEdgeCases(Float32.self)
+    testAngleAxisEdgeCases(Float64.self)
+  }
+
+  // MARK: Rotation Vector
+
+  func testRotationVector<T: Real & SIMDScalar>(_ type: T.Type) {
+    let vector = SIMD3<T>(0,-1,0) * .pi
+    XCTAssertEqual(Quaternion<T>(rotation: vector).rotationVector.x,  .zero)
+    XCTAssertEqual(Quaternion<T>(rotation: vector).rotationVector.y, -.pi)
+    XCTAssertEqual(Quaternion<T>(rotation: vector).rotationVector.z,  .zero)
+
+    XCTAssertEqual(Quaternion<T>(rotation: vector).axis, SIMD3(0,-1,0))
+    XCTAssertEqual(Quaternion<T>(rotation: vector).angle, .pi)
+  }
+
+  func testRotationVector() {
+    testRotationVector(Float32.self)
+    testRotationVector(Float64.self)
+  }
+
+  func testRotationVectorEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
+    XCTAssertEqual(Quaternion<T>(rotation: .zero), .zero)
+    XCTAssertEqual(Quaternion<T>(rotation: .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(rotation: -.infinity), .infinity)
+    XCTAssertTrue(Quaternion<T>(rotation: .nan).real.isNaN)
+    XCTAssertTrue(Quaternion<T>(rotation: .nan).imaginary.isNaN)
+  }
+
+  func testRotationVectorEdgeCases() {
+    testRotationVectorEdgeCases(Float32.self)
+    testRotationVectorEdgeCases(Float64.self)
+  }
+
+  // MARK: Polar Decomposition
+
+  func testPolarDecomposition<T: Real & SIMDScalar>(_ type: T.Type) {
+    let axis = SIMD3<T>(0,-1,0)
+
+    let q = Quaternion<T>(length: 5, halfAngle: .pi, axis: axis)
+    XCTAssertEqual(q.axis, axis)
+    XCTAssertEqual(q.angle, .pi * 2)
+
+    XCTAssertEqual(q.polar.length, 5)
+    XCTAssertEqual(q.polar.halfAngle, .pi)
+    XCTAssertEqual(q.polar.axis, axis)
+  }
+
+  func testPolarDecomposition() {
+    testPolarDecomposition(Float32.self)
+    testPolarDecomposition(Float64.self)
+  }
+
+  func testPolarDecompositionEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
+    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle: .infinity, axis:  .infinity), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle:-.infinity, axis: -.infinity), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .zero, halfAngle: .nan     , axis:  .nan     ), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle: .infinity, axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle:-.infinity, axis: -.infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, halfAngle: .nan     , axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle: .infinity, axis:  .infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle:-.infinity, axis: -.infinity), .infinity)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, halfAngle: .nan     , axis:  .infinity), .infinity)
+  }
+
+  func testPolarDecompositionEdgeCases() {
+    testPolarDecompositionEdgeCases(Float32.self)
+    testPolarDecompositionEdgeCases(Float64.self)
+  }
+}
+
+// Helper
+extension SIMD3 where Scalar: FloatingPoint {
+  fileprivate static var infinity: Self { SIMD3(.infinity,0,0) }
+  fileprivate static var nan: Self { SIMD3(.nan,0,0) }
+  fileprivate var isNaN: Bool { x.isNaN && y.isNaN && z.isNaN }
+}

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -1,4 +1,4 @@
-//===--- PolarTests.swift -------------------------------------*- swift -*-===//
+//===--- TransformationTests.swift ----------------------------*- swift -*-===//
 //
 // This source file is part of the Swift Numerics open source project
 //
@@ -18,7 +18,7 @@ final class TransformationTests: XCTestCase {
 
   // MARK: Angle/Axis
 
-  func testAngleAxisSpin<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testAngleAxis<T: Real & SIMDScalar>(_ type: T.Type) {
     let xAxis = SIMD3<T>(1,0,0)
     // Positive angle, positive axis
     XCTAssertEqual(Quaternion<T>(angle: .pi, axis: xAxis).angle, .pi)
@@ -34,12 +34,12 @@ final class TransformationTests: XCTestCase {
     XCTAssertEqual(Quaternion<T>.init(angle: -.pi, axis: -xAxis).axis, xAxis)
   }
 
-  func testAngleAxisSpin() {
-    testAngleAxisSpin(Float32.self)
-    testAngleAxisSpin(Float64.self)
+  func testAngleAxis() {
+    testAngleAxis(Float32.self)
+    testAngleAxis(Float64.self)
   }
 
-  func testAngleMultipleOfPi<T: Real & SIMDScalar>(_ type: T.Type) {
+  func testAngleAxisMultipleOfPi<T: Real & SIMDScalar>(_ type: T.Type) {
     let xAxis = SIMD3<T>(1,0,0)
     // 2π
     let pi2 = Quaternion<T>(angle: .pi * 2, axis: xAxis)
@@ -47,21 +47,17 @@ final class TransformationTests: XCTestCase {
     XCTAssertEqual(pi2.axis, xAxis)
     // 3π - axis inverted
     let pi3 = Quaternion<T>(angle: .pi * 3, axis: xAxis)
-    XCTAssertEqual(pi3.angle, .pi, accuracy: .ulpOfOne * 2)
+    XCTAssertTrue(closeEnough(pi3.angle, .pi, ulps: 1))
     XCTAssertEqual(pi3.axis, -xAxis)
-    // 4π - axis inverted
-    let pi4 = Quaternion<T>(angle: .pi * 4, axis: xAxis)
-    XCTAssertEqual(pi4.angle, .zero, accuracy: .ulpOfOne * 6)
-    XCTAssertEqual(pi4.axis, -xAxis)
     // 5π - axis restored
     let pi5 = Quaternion<T>(angle: .pi * 5, axis: xAxis)
-    XCTAssertEqual(pi5.angle, .pi, accuracy: .ulpOfOne * 10)
+    XCTAssertTrue(closeEnough(pi5.angle, .pi, ulps: 5))
     XCTAssertEqual(pi5.axis, xAxis)
   }
 
-  func testAngleMultipleOfPi() {
-    testAngleMultipleOfPi(Float32.self)
-    testAngleMultipleOfPi(Float64.self)
+  func testAngleAxisMultipleOfPi() {
+    testAngleAxisMultipleOfPi(Float32.self)
+    testAngleAxisMultipleOfPi(Float64.self)
   }
 
   func testAngleAxisEdgeCases<T: Real & SIMDScalar>(_ type: T.Type) {
@@ -185,11 +181,143 @@ final class TransformationTests: XCTestCase {
     testPolarDecompositionEdgeCases(Float32.self)
     testPolarDecompositionEdgeCases(Float64.self)
   }
+
+  // MARK: Act on Vector
+
+  func testActOnVector<T: Real & SIMDScalar>(_ type: T.Type) {
+    let vector = SIMD3<T>(1,1,1)
+    let xAxis = SIMD3<T>(1,0,0)
+
+    let piHalf = Quaternion<T>(angle: .pi/2, axis: xAxis)
+    XCTAssertTrue(closeEnough(piHalf.act(on: vector).x,  1, ulps: 0))
+    XCTAssertTrue(closeEnough(piHalf.act(on: vector).y, -1, ulps: 1))
+    XCTAssertTrue(closeEnough(piHalf.act(on: vector).z,  1, ulps: 1))
+
+    let pi = Quaternion<T>(angle: .pi, axis: xAxis)
+    XCTAssertTrue(closeEnough(pi.act(on: vector).x,  1, ulps: 0))
+    XCTAssertTrue(closeEnough(pi.act(on: vector).y, -1, ulps: 2))
+    XCTAssertTrue(closeEnough(pi.act(on: vector).z, -1, ulps: 2))
+
+    let twoPi = Quaternion<T>(angle: .pi * 2, axis: xAxis)
+    XCTAssertTrue(closeEnough(twoPi.act(on: vector).x,  1, ulps: 0))
+    XCTAssertTrue(closeEnough(twoPi.act(on: vector).y,  1, ulps: 3))
+    XCTAssertTrue(closeEnough(twoPi.act(on: vector).z,  1, ulps: 3))
+  }
+
+  func testActOnVector() {
+    testActOnVector(Float32.self)
+    testActOnVector(Float64.self)
+  }
+
+  func testActOnVectorRandom<T>(_ type: T.Type)
+    where T: Real, T: BinaryFloatingPoint, T: SIMDScalar,
+    T.Exponent: FixedWidthInteger, T.RawSignificand: FixedWidthInteger
+  {
+    // Generate random angles, axis and vector to test rotation properties
+    // - angle are selected from range -π to π
+    // - axis values are selected from -1 to 1; axis length is unity
+    // - vector values are selected from 10 to 10000
+    let inputs: [(angle: T, axis: SIMD3<T>, vector: SIMD3<T>)] = (0..<100).map { _ in
+      let angle = T.random(in: -.pi ... .pi)
+      var axis = SIMD3<T>.random(in: -1 ... 1)
+      axis /= .sqrt((axis * axis).sum()) // Normalize
+      var vector = SIMD3<T>.random(in: -1 ... 1)
+      vector /= .sqrt((vector * vector).sum()) // Normalize
+      vector *= T.random(in: 10 ... 10000)     // Scale
+      return (angle, axis, vector)
+    }
+
+    for (angle, axis, vector) in inputs {
+      let q = Quaternion(angle: angle, axis: axis)
+      // The following equation in the form of v' = qvq⁻¹ is the mathmatical
+      // definition for how a quaternion rotates a vector (by promoting it to
+      // a quaternion) and goes "the full and long way" to calculate the
+      // rotation of vector by a quaternion. The result is used to test the
+      // rotation properties of "act(on:)"
+      let vrot = (q                     // q
+        * Quaternion(imaginary: vector) // v   (pure quaternion)
+        * q.conjugate                   // q⁻¹ (as q is of unit length, q⁻¹ == q*)
+      ).imaginary // the result is pure quaternion with v' == imaginary
+
+      XCTAssertTrue(q.act(on: vector).x.isFinite)
+      XCTAssertTrue(q.act(on: vector).y.isFinite)
+      XCTAssertTrue(q.act(on: vector).z.isFinite)
+      // Test for sign equality on the components to see if the vector rotated
+      // to the correct quadrant and if the vector is of equal in length,
+      // instead of testing component equality – as they are hard to compare
+      // with proper tolerance
+      XCTAssertEqual(q.act(on: vector).x.sign, vrot.x.sign)
+      XCTAssertEqual(q.act(on: vector).y.sign, vrot.y.sign)
+      XCTAssertEqual(q.act(on: vector).z.sign, vrot.z.sign)
+      XCTAssertTrue(closeEnough(q.act(on: vector).lengthSquared, vrot.lengthSquared, ulps: 16))
+    }
+  }
+
+  func testActOnVectorRandom() {
+    testActOnVectorRandom(Float32.self)
+    testActOnVectorRandom(Float64.self)
+  }
+
+  func testActOnVectorEdgeCase<T: Real & ExpressibleByFloatLiteral & SIMDScalar>(_ type: T.Type) {
+
+    /// Test for zero, infinity
+    let q = Quaternion(angle: .pi, axis: SIMD3(1,0,0))
+    XCTAssertEqual(q.act(on:  .zero), .zero)
+    XCTAssertEqual(q.act(on: -.zero), .zero)
+    XCTAssertEqual(q.act(on:  .infinity), SIMD3(repeating: .infinity))
+    XCTAssertEqual(q.act(on: -.infinity), SIMD3(repeating: .infinity))
+
+    // Rotate a vector with a value close to greatestFiniteMagnitude
+    // in all lanes.
+    // A vector this close to the bounds should not hit infinity when it
+    // is rotate by a perpendicular axis with an angle that is a multiple of π
+
+    // An axis perpendicular to the vector, so all lanes are changing equally
+    let axis = SIMD3<T>(1/2,0,-1/2)
+    // Create a value close (somewhat) close to .greatestFiniteMagnitude
+    let scalar = T(
+      sign: .plus, exponent: T.greatestFiniteMagnitude.exponent,
+      significand: 1.999999
+    )
+
+    let closeToBounds = SIMD3<T>(repeating: scalar)
+
+    // Perform a 180° rotation on all components
+    let pi = Quaternion(angle: .pi, axis: axis).act(on: closeToBounds)
+    // Must be finite after the rotation
+    XCTAssertTrue(pi.x.isFinite)
+    XCTAssertTrue(pi.y.isFinite)
+    XCTAssertTrue(pi.z.isFinite)
+    XCTAssertTrue(closeEnough(pi.x, -scalar, ulps: 4))
+    XCTAssertTrue(closeEnough(pi.y, -scalar, ulps: 4))
+    XCTAssertTrue(closeEnough(pi.z, -scalar, ulps: 4))
+
+    // Perform a 360° rotation on all components
+    let twoPi = Quaternion(angle: 2 * .pi, axis: axis).act(on: closeToBounds)
+    // Must still be finite after the process
+    XCTAssertTrue(twoPi.x.isFinite)
+    XCTAssertTrue(twoPi.y.isFinite)
+    XCTAssertTrue(twoPi.z.isFinite)
+    XCTAssertTrue(closeEnough(twoPi.x, scalar, ulps: 8))
+    XCTAssertTrue(closeEnough(twoPi.y, scalar, ulps: 8))
+    XCTAssertTrue(closeEnough(twoPi.z, scalar, ulps: 8))
+  }
+
+  func testActOnVectorEdgeCase() {
+    testActOnVectorEdgeCase(Float32.self)
+    testActOnVectorEdgeCase(Float64.self)
+  }
 }
 
-// Helper
+// MARK: - Helper
 extension SIMD3 where Scalar: FloatingPoint {
   fileprivate static var infinity: Self { SIMD3(.infinity,0,0) }
   fileprivate static var nan: Self { SIMD3(.nan,0,0) }
   fileprivate var isNaN: Bool { x.isNaN && y.isNaN && z.isNaN }
+}
+
+// TODO: replace with approximately equals
+func closeEnough<T: Real>(_ a: T, _ b: T, ulps allowed: T) -> Bool {
+  let scale = max(a.magnitude, b.magnitude, T.leastNormalMagnitude).ulp
+  return (a - b).magnitude <= allowed * scale
 }

--- a/Tests/QuaternionTests/TransformationTests.swift
+++ b/Tests/QuaternionTests/TransformationTests.swift
@@ -116,6 +116,36 @@ final class TransformationTests: XCTestCase {
     testAngleAxisEdgeCases(Float64.self)
   }
 
+  func testHalfAngleAndAxisOverflow<T: Real & SIMDScalar>(_ type: T.Type) {
+    let unscaled = Quaternion<T>(1, SIMD3(repeating: 1))
+    let scaled = Quaternion<T>(
+      .greatestFiniteMagnitude,
+      SIMD3(repeating: .greatestFiniteMagnitude)
+    )
+    XCTAssertEqual(scaled.angle, unscaled.angle)
+    XCTAssertEqual(scaled.axis, unscaled.axis)
+  }
+
+  func testHalfAngleAndAxisOverflow() {
+    testHalfAngleAndAxisOverflow(Float32.self)
+    testHalfAngleAndAxisOverflow(Float64.self)
+  }
+
+  func testHalfAngleAndAxisUnderflow<T: Real & SIMDScalar>(_ type: T.Type) {
+    let unscaled = Quaternion<T>(1, SIMD3(repeating: 1))
+    let scaled = Quaternion<T>(
+      .leastNormalMagnitude,
+      SIMD3(repeating: .leastNormalMagnitude)
+    )
+    XCTAssertEqual(scaled.angle, unscaled.angle)
+    XCTAssertEqual(scaled.axis, unscaled.axis)
+  }
+
+  func testHalfAngleAndAxisUnderflow() {
+    testHalfAngleAndAxisUnderflow(Float32.self)
+    testHalfAngleAndAxisUnderflow(Float64.self)
+  }
+
   // MARK: Rotation Vector
 
   func testRotationVector<T: Real & SIMDScalar>(_ type: T.Type) {
@@ -170,11 +200,11 @@ final class TransformationTests: XCTestCase {
     XCTAssertEqual(Quaternion<T>(length: .zero, phase: .infinity, axis:  .infinity), .zero)
     XCTAssertEqual(Quaternion<T>(length: .zero, phase:-.infinity, axis: -.infinity), .zero)
     XCTAssertEqual(Quaternion<T>(length: .zero, phase: .nan     , axis:  .nan     ), .zero)
-    XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .zero    , axis:  .zero    ), .zero)
+    XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .zero    , axis:  .zero    ), .infinity)
     XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .infinity, axis:  .infinity), .infinity)
     XCTAssertEqual(Quaternion<T>(length: .infinity, phase:-.infinity, axis: -.infinity), .infinity)
     XCTAssertEqual(Quaternion<T>(length: .infinity, phase: .nan     , axis:  .infinity), .infinity)
-    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .zero    , axis:  .zero    ), .zero)
+    XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .zero    , axis:  .zero    ), .infinity)
     XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .infinity, axis:  .infinity), .infinity)
     XCTAssertEqual(Quaternion<T>(length:-.infinity, phase:-.infinity, axis: -.infinity), .infinity)
     XCTAssertEqual(Quaternion<T>(length:-.infinity, phase: .nan     , axis:  .infinity), .infinity)


### PR DESCRIPTION
This PR adds an API for working with other representations of transformations, such as [*Angle-Axis*][angle_axis_wiki], [*Polar*][polar_wiki] and [*Rotation Vector*][rotation_vector_wiki]. The API provides operations to convert from these representations to `Quaternion` and vice versa.

Additionally, the API provides a method to directly rotate an arbitrary vector by a quaternion and thus avoids the calculation of an intermediate representation to any other form in the process.

[angle_axis_wiki]: https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation#Recovering_the_axis-angle_representation
[polar_wiki]: https://en.wikipedia.org/wiki/Polar_decomposition#Quaternion_polar_decomposition
[rotation_vector_wiki]: https://en.wikipedia.org/wiki/Axis–angle_representation#Rotation_vector