### PR TITLE
Explicitly require parameter names on SIMD initializer of quaternions

### DIFF
--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -254,23 +254,23 @@ extension Quaternion {
 extension Quaternion {
   /// The quaternion with specified real part and zero imaginary part.
   ///
-  /// Equivalent to `Quaternion(real, SIMD3(repeating: 0))`.
+  /// Equivalent to `Quaternion(real: real, imaginary: SIMD3(repeating: 0))`.
   @inlinable
   public init(_ real: RealType) {
-    self.init(real, SIMD3(repeating: 0))
+    self.init(real: real, imaginary: SIMD3(repeating: 0))
   }
 
   /// The quaternion with specified imaginary part and zero real part.
   ///
-  /// Equivalent to `Quaternion(0, imaginary)`.
+  /// Equivalent to `Quaternion(real: 0, imaginary: imaginary)`.
   @inlinable
   public init(imaginary: SIMD3<RealType>) {
-    self.init(0, imaginary)
+    self.init(real: 0, imaginary: imaginary)
   }
 
   /// The quaternion with specified imaginary part and zero real part.
   ///
-  /// Equivalent to `Quaternion(0, imaginary)`.
+  /// Equivalent to `Quaternion(real: 0, imaginary: imaginary)`.
   @inlinable
   public init(imaginary x: RealType, _ y: RealType, _ z: RealType) {
     self.init(imaginary: SIMD3(x, y, z))
@@ -278,14 +278,14 @@ extension Quaternion {
 
   /// The quaternion with specified real part and imaginary parts.
   @inlinable
-  public init(_ real: RealType, _ imaginary: SIMD3<RealType>) {
+  public init(real: RealType, imaginary: SIMD3<RealType>) {
     self.init(from: SIMD4(imaginary, real))
   }
 
   /// The quaternion with specified real part and imaginary parts.
   @inlinable
   public init(real: RealType, imaginary x: RealType, _ y: RealType, _ z: RealType) {
-    self.init(real, SIMD3(x, y, z))
+    self.init(real: real, imaginary: SIMD3(x, y, z))
   }
 
   /// The quaternion with specified real part and zero imaginary part.

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -32,8 +32,8 @@ final class PropertyTests: XCTestCase {
     XCTAssertEqual(Quaternion<T>(real: .nan, imaginary: 0, 0, 0).length, .infinity)
     // The length of a zero value should be zero.
     XCTAssertEqual(Quaternion<T>.zero.length, .zero)
-    XCTAssertEqual(Quaternion<T>(.zero, -.zero).length, .zero)
-    XCTAssertEqual(Quaternion<T>(-.zero, -.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(real: .zero, imaginary: -.zero).length, .zero)
+    XCTAssertEqual(Quaternion<T>(real: -.zero, imaginary: -.zero).length, .zero)
   }
 
   func testProperties() {


### PR DESCRIPTION
This PR changes quaternions so they explicitly require parameter names on the SIMD initializer, i.e.

```swift
public init(_ real: RealType, _ imaginary: SIMD3<RealType>)
```

becomes

```swift
public init(real: RealType, imaginary: SIMD3<RealType>)
```

---

This change makes the SIMD initializer align better with the "non-SIMD" initializer:
```swift
init(real: RealType, imaginary x: RealType, _ y: RealType, _ z: RealType)
```
which, during the Sketch PR, has been changed to explicitly require parameter names.