### PR TITLE
The future is now

### DIFF
--- a/Sources/ComplexModule/Differentiable.swift
+++ b/Sources/ComplexModule/Differentiable.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(_Differentiation)
+#if swift(>=5.3) && canImport(_Differentiation)
 import _Differentiation
 
 extension Complex: Differentiable

--- a/Sources/ComplexModule/Differentiable.swift
+++ b/Sources/ComplexModule/Differentiable.swift
@@ -24,6 +24,16 @@ where RealType: Differentiable, RealType.TangentVector == RealType {
 
 extension Complex
 where RealType: Differentiable, RealType.TangentVector == RealType {
+  @derivative(of: init(_:_:))
+  @usableFromInline
+  static func _derivativeInit(
+    _ real: RealType,
+    _ imaginary: RealType
+  ) -> (value: Complex, pullback: (Complex) -> (RealType, RealType)) {
+    (value: .init(real, imaginary), pullback: { v in
+      (v.real, v.imaginary)
+    })
+  }
 
   @derivative(of: real)
   @usableFromInline

--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.3)
 import _NumericsShims
 
 @available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
@@ -172,3 +173,4 @@ extension Float16: Real {
   }
   #endif
 }
+#endif

--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -1,0 +1,174 @@
+//===--- Float16+Real.swift -----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import _NumericsShims
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+extension Float16: Real {
+  @_transparent
+  public static func cos(_ x: Float16) -> Float16 {
+    Float16(.cos(Float(x)))
+  }
+  
+  @_transparent
+  public static func sin(_ x: Float16) -> Float16 {
+    Float16(.sin(Float(x)))
+  }
+  
+  @_transparent
+  public static func tan(_ x: Float16) -> Float16 {
+    Float16(.tan(Float(x)))
+  }
+  
+  @_transparent
+  public static func acos(_ x: Float16) -> Float16 {
+    Float16(.acos(Float(x)))
+  }
+  
+  @_transparent
+  public static func asin(_ x: Float16) -> Float16 {
+    Float16(.asin(Float(x)))
+  }
+  
+  @_transparent
+  public static func atan(_ x: Float16) -> Float16 {
+    Float16(.atan(Float(x)))
+  }
+  
+  @_transparent
+  public static func cosh(_ x: Float16) -> Float16 {
+    Float16(.cosh(Float(x)))
+  }
+  
+  @_transparent
+  public static func sinh(_ x: Float16) -> Float16 {
+    Float16(.sinh(Float(x)))
+  }
+  
+  @_transparent
+  public static func tanh(_ x: Float16) -> Float16 {
+    Float16(.tanh(Float(x)))
+  }
+  
+  @_transparent
+  public static func acosh(_ x: Float16) -> Float16 {
+    Float16(.acosh(Float(x)))
+  }
+  
+  @_transparent
+  public static func asinh(_ x: Float16) -> Float16 {
+    Float16(.asinh(Float(x)))
+  }
+  
+  @_transparent
+  public static func atanh(_ x: Float16) -> Float16 {
+    Float16(.atanh(Float(x)))
+  }
+  
+  @_transparent
+  public static func exp(_ x: Float16) -> Float16 {
+    Float16(.exp(Float(x)))
+  }
+  
+  @_transparent
+  public static func expMinusOne(_ x: Float16) -> Float16 {
+    Float16(.expMinusOne(Float(x)))
+  }
+  
+  @_transparent
+  public static func log(_ x: Float16) -> Float16 {
+    Float16(.log(Float(x)))
+  }
+  
+  @_transparent
+  public static func log(onePlus x: Float16) -> Float16 {
+    Float16(.log(onePlus: Float(x)))
+  }
+  
+  @_transparent
+  public static func erf(_ x: Float16) -> Float16 {
+    Float16(.erf(Float(x)))
+  }
+  
+  @_transparent
+  public static func erfc(_ x: Float16) -> Float16 {
+    Float16(.erfc(Float(x)))
+  }
+  
+  @_transparent
+  public static func exp2(_ x: Float16) -> Float16 {
+    Float16(.exp2(Float(x)))
+  }
+  
+  @_transparent
+  public static func exp10(_ x: Float16) -> Float16 {
+    Float16(.exp10(Float(x)))
+  }
+  
+  @_transparent
+  public static func hypot(_ x: Float16, _ y: Float16) -> Float16 {
+    if x.isInfinite || y.isInfinite { return .infinity }
+    let xf = Float(x)
+    let yf = Float(y)
+    return Float16(.sqrt(xf*xf + yf*yf))
+  }
+  
+  @_transparent
+  public static func gamma(_ x: Float16) -> Float16 {
+    Float16(.gamma(Float(x)))
+  }
+  
+  @_transparent
+  public static func log2(_ x: Float16) -> Float16 {
+    Float16(.log2(Float(x)))
+  }
+  
+  @_transparent
+  public static func log10(_ x: Float16) -> Float16 {
+    Float16(.log10(Float(x)))
+  }
+  
+  @_transparent
+  public static func pow(_ x: Float16, _ y: Float16) -> Float16 {
+    Float16(.pow(Float(x), Float(y)))
+  }
+  
+  @_transparent
+  public static func pow(_ x: Float16, _ n: Int) -> Float16 {
+    // Float16 is simpler than Float or Double, because the range of
+    // "interesting" exponents is pretty small; anything outside of
+    // -22707 ... 34061 simply overflows or underflows for every
+    // x that isn't zero or one. This whole range is representable
+    // as Float, so we can just use powf as long as we're a little
+    // bit (get it?) careful to preserve parity.
+    let clamped = min(max(n, -0x10000), 0x10000) | (n & 1)
+    return Float16(libm_powf(Float(x), Float(clamped)))
+  }
+  
+  @_transparent
+  public static func root(_ x: Float16, _ n: Int) -> Float16 {
+    Float16(.root(Float(x), n))
+  }
+  
+  @_transparent
+  public static func atan2(y: Float16, x: Float16) -> Float16 {
+    Float16(.atan2(y: Float(y), x: Float(x)))
+  }
+  
+  #if !os(Windows)
+  @_transparent
+  public static func logGamma(_ x: Float16) -> Float16 {
+    Float16(.logGamma(Float(x)))
+  }
+  #endif
+}

--- a/Sources/_NumericsShims/include/_NumericsShims.h
+++ b/Sources/_NumericsShims/include/_NumericsShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019-2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -383,11 +383,9 @@ HEADER_SHIM long double libm_lgammal(long double x, int *signp) {
 #endif
 
 // MARK: - shims to import C complex operations for timing purposes
+// Clang doesn't provide complex arithmetic on Windows (because MSVC
+// doesn't), so we can't define these there, or we'll get link errors.
 #if !defined _WIN32
-// Clang doesn't have support for complex arithmetic on Windows, so
-// it doesn't make sense to benchmark against it (and these will
-// fail to link if used there).
-
 typedef struct { double real; double imag; } CComplex;
 
 HEADER_SHIM CComplex libm_cdiv(CComplex z, CComplex w) {
@@ -403,5 +401,4 @@ HEADER_SHIM CComplex libm_cmul(CComplex z, CComplex w) {
   double _Complex c = a*b;
   return (CComplex){ __real__ c, __imag__ c };
 }
-
-#endif
+#endif // !defined _WIN32

--- a/Tests/ComplexTests/DifferentiableTests.swift
+++ b/Tests/ComplexTests/DifferentiableTests.swift
@@ -28,6 +28,18 @@ final class DifferentiableTests: XCTestCase {
       Complex(5, 2))
   }
 
+  func testInitializer() {
+    let φ1 = pullback(at: 4, -3) { r, i in Complex<Float>(r, i) }
+    let tan1 = φ1(Complex(-1, 2))
+    XCTAssertEqual(tan1.0, -1)
+    XCTAssertEqual(tan1.1, 2)
+
+    let φ2 = pullback(at: 4, -3) { r, i in Complex<Float>(r * r, i + i) }
+    let tan2 = φ2(Complex(-1, 1))
+    XCTAssertEqual(tan2.0, -8)
+    XCTAssertEqual(tan2.1, 2)
+  }
+
   func testConjugate() {
     let φ = pullback(at: Complex<Float>(20, -4)) { x in x.conjugate }
     XCTAssertEqual(φ(Complex(1, 0)), Complex(1, 0))

--- a/Tests/ComplexTests/DifferentiableTests.swift
+++ b/Tests/ComplexTests/DifferentiableTests.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(_Differentiation)
+#if swift(>=5.3) && canImport(_Differentiation)
 
 import XCTest
 import ComplexModule

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -76,6 +76,34 @@ internal extension Real where Self: FixedWidthFloatingPoint {
   }
 }
 
+@available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
+@available(macOS, unavailable)
+extension Float16 {
+  static func testIntegerExponent() {
+    testIntegerExponentCommon()
+    testIntegerExponentDoubleAndSmaller()
+    let u = Float16(1).nextUp
+    let d = Float16(1).nextDown
+    // Smallest exponents not exactly representable as Float16.
+    assertClose(-7.3890572722436554354625993393835304, Float16.pow(-u, 0x801))
+    assertClose(-0.3676100238077049750885141244927184, Float16.pow(-d, 0x801))
+    // Exponents close to overflow boundary.
+    assertClose( 65403.86633107, Float16.pow(-u, 11360))
+    assertClose(-65467.73729429, Float16.pow(-u, 11361))
+    assertClose( 65531.67063149, Float16.pow(-u, 11362))
+    assertClose( 65487.96799785, Float16.pow(-d, -22706))
+    assertClose(-65519.96016590, Float16.pow(-d, -22707))
+    assertClose( 65551.96796276, Float16.pow(-d, -22708))
+    // Exponents close to underflow boundary.
+    assertClose( 5.966876499900e-8, Float16.pow(-u, -17042))
+    assertClose(-5.961055156973e-8, Float16.pow(-u, -17043))
+    assertClose( 5.955239493405e-8, Float16.pow(-u, -17044))
+    assertClose( 5.964109628044e-8, Float16.pow(-d, 34060))
+    assertClose(-5.961197465140e-8, Float16.pow(-d, 34061))
+    assertClose( 5.958286724190e-8, Float16.pow(-d, 34062))
+  }
+}
+
 extension Float {
   static func testIntegerExponent() {
     testIntegerExponentCommon()
@@ -134,6 +162,14 @@ extension Double {
 }
 
 final class IntegerExponentTests: XCTestCase {
+  
+  @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
+  func testFloat16() {
+    Float16.testIntegerExponent()
+  }
+  
   func testFloat() {
     Float.testIntegerExponent()
   }

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -76,6 +76,7 @@ internal extension Real where Self: FixedWidthFloatingPoint {
   }
 }
 
+#if swift(>=5.3)
 @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
 @available(macOS, unavailable)
 extension Float16 {
@@ -103,6 +104,7 @@ extension Float16 {
     assertClose( 5.958286724190e-8, Float16.pow(-d, 34062))
   }
 }
+#endif
 
 extension Float {
   static func testIntegerExponent() {
@@ -162,13 +164,15 @@ extension Double {
 }
 
 final class IntegerExponentTests: XCTestCase {
-  
+
+  #if swift(>=5.3)
   @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
   @available(macOS, unavailable)
   @available(macCatalyst, unavailable)
   func testFloat16() {
     Float16.testIntegerExponent()
   }
+  #endif
   
   func testFloat() {
     Float.testIntegerExponent()

--- a/Tests/RealTests/RealTestSupport.swift
+++ b/Tests/RealTests/RealTestSupport.swift
@@ -23,7 +23,7 @@ func assertClose<T>(
   _ expected: TestLiteralType,
   _ observed: T,
   allowedError: T = 16,
-  file: StaticString = #filePath,
+  file: StaticString = #file,
   line: UInt = #line
 ) -> T where T: BinaryFloatingPoint {
   // Shortcut relative-error check if we got the sign wrong; it's OK to
@@ -74,7 +74,7 @@ func assertClose<T>(
   _ observed: T,
   allowedError: T = 16,
   worstError: inout T,
-  file: StaticString = #filePath,
+  file: StaticString = #file,
   line: UInt = #line
 ) where T: BinaryFloatingPoint {
   worstError = max(worstError, assertClose(
@@ -86,10 +86,12 @@ internal protocol FixedWidthFloatingPoint: BinaryFloatingPoint
 where Exponent: FixedWidthInteger,
       RawSignificand: FixedWidthInteger { }
 
+#if swift(>=5.3)
 @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 extension Float16: FixedWidthFloatingPoint { }
+#endif
 
 extension Float: FixedWidthFloatingPoint { }
 extension Double: FixedWidthFloatingPoint { }

--- a/Tests/RealTests/RealTestSupport.swift
+++ b/Tests/RealTests/RealTestSupport.swift
@@ -23,7 +23,7 @@ func assertClose<T>(
   _ expected: TestLiteralType,
   _ observed: T,
   allowedError: T = 16,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) -> T where T: BinaryFloatingPoint {
   // Shortcut relative-error check if we got the sign wrong; it's OK to
@@ -74,7 +74,7 @@ func assertClose<T>(
   _ observed: T,
   allowedError: T = 16,
   worstError: inout T,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) where T: BinaryFloatingPoint {
   worstError = max(worstError, assertClose(
@@ -85,6 +85,11 @@ func assertClose<T>(
 internal protocol FixedWidthFloatingPoint: BinaryFloatingPoint
 where Exponent: FixedWidthInteger,
       RawSignificand: FixedWidthInteger { }
+
+@available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+extension Float16: FixedWidthFloatingPoint { }
 
 extension Float: FixedWidthFloatingPoint { }
 extension Double: FixedWidthFloatingPoint { }

--- a/Tests/RealTests/RealTests.swift
+++ b/Tests/RealTests/RealTests.swift
@@ -59,7 +59,7 @@ internal extension Real where Self: BinaryFloatingPoint {
 
 final class ElementaryFunctionChecks: XCTestCase {
   
-  #if !os(macOS)
+  #if swift(>=5.3) && !os(macOS)
   func testFloat16() {
     if #available(iOS 14.0, watchOS 14.0, tvOS 7.0, *) {
       Float16.elementaryFunctionChecks()

--- a/Tests/RealTests/RealTests.swift
+++ b/Tests/RealTests/RealTests.swift
@@ -59,6 +59,15 @@ internal extension Real where Self: BinaryFloatingPoint {
 
 final class ElementaryFunctionChecks: XCTestCase {
   
+  #if !os(macOS)
+  func testFloat16() {
+    if #available(iOS 14.0, watchOS 14.0, tvOS 7.0, *) {
+      Float16.elementaryFunctionChecks()
+      Float16.realFunctionChecks()
+    }
+  }
+  #endif
+  
   func testFloat() {
     Float.elementaryFunctionChecks()
     Float.realFunctionChecks()

--- a/Tests/WindowsMain.swift
+++ b/Tests/WindowsMain.swift
@@ -40,16 +40,6 @@ extension ArithmeticTests {
   ])
 }
 
-#if canImport(_Differentiation)
-  extension DifferentiableTests {
-    static var all = testCase([
-      ("testComponentGetter", DifferentiableTests.testComponentGetter),
-      ("testConjugate",  DifferentiableTests.testConjugate),
-      ("testArithmetics", DifferentiableTests.testArithmetics),
-    ])
-  }
-#endif
-
 extension PropertyTests {
   static var all = testCase([
     ("testProperties", PropertyTests.testProperties),
@@ -65,7 +55,15 @@ var testCases = [
   PropertyTests.all,
 ]
 
-#if canImport(_Differentiation)
+#if swift(>=5.3) && canImport(_Differentiation)
+extension DifferentiableTests {
+  static var all = testCase([
+    ("testComponentGetter", DifferentiableTests.testComponentGetter),
+    ("testConjugate",  DifferentiableTests.testConjugate),
+    ("testArithmetics", DifferentiableTests.testArithmetics),
+  ])
+}
+
 testCases += [
   DifferentiableTests.all
 ]


### PR DESCRIPTION
Merge the experimental 5.3 feature branch into master, behind a Swift version check.

This makes Swift Numerics extensions for Float16 available if the following criteria are satisfied:
- You are using a Swift 5.3 or greater toolchain
- You are not compiling for macOS (Float16 is not available in the macOS standard library because Intel hasn't defined the calling conventions for Float16 yet, so it cannot be made binary-stable).

This also adds a Swift version check for differentiable features; they are now only available when using Swift 5.3 or later, while previously they only checked if _Differentiation could be imported.