### PR TITLE
Tests: add new tests to the Windows test suite

### DIFF
--- a/Tests/ComplexTests/CMakeLists.txt
+++ b/Tests/ComplexTests/CMakeLists.txt
@@ -8,6 +8,7 @@ See https://swift.org/LICENSE.txt for license information
 #]]
 
 add_library(ComplexTests
+  ApproximateEqualityTests.swift
   ArithmeticTests.swift
   DifferentiableTests.swift
   PropertyTests.swift)
@@ -18,4 +19,5 @@ target_compile_options(ComplexTests PRIVATE
 target_link_libraries(ComplexTests PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   ComplexModule
+  Numerics
   XCTest)

--- a/Tests/WindowsMain.swift
+++ b/Tests/WindowsMain.swift
@@ -18,19 +18,53 @@ import RealTests
 @testable
 import ComplexTests
 
+extension ComplexTests.ElementaryFunctionTests {
+  static var all = testCase([
+    ("testFloat", RealTests.ElementaryFunctionTests.testFloat),
+    ("testDouble", RealTests.ElementaryFunctionTests.testDouble),
+  ])
+}
+
+extension RealTests.ElementaryFunctionTests {
+  static var all = testCase([
+    ("testFloat", RealTests.ElementaryFunctionTests.testFloat),
+    ("testDouble", RealTests.ElementaryFunctionTests.testDouble),
+  ])
+}
+
+#if swift(>=5.3)
+extension ElementaryFunctionChecks {
+  static var all = testCase([
+    ("testFloat16", ElementaryFunctionChecks.testFloat16),
+    ("testFloat", ElementaryFunctionChecks.testFloat),
+    ("testDouble", ElementaryFunctionChecks.testDouble),
+  ])
+}
+#else
 extension ElementaryFunctionChecks {
   static var all = testCase([
     ("testFloat", ElementaryFunctionChecks.testFloat),
     ("testDouble", ElementaryFunctionChecks.testDouble),
   ])
 }
+#endif
 
+#if swift(>=5.3)
+extension IntegerExponentTests {
+  static var all = testCase([
+    ("testFloat16", IntegerExponentTests.testFloat16),
+    ("testFloat", IntegerExponentTests.testFloat),
+    ("testDouble", IntegerExponentTests.testDouble),
+  ])
+}
+#else
 extension IntegerExponentTests {
   static var all = testCase([
     ("testFloat", IntegerExponentTests.testFloat),
     ("testDouble", IntegerExponentTests.testDouble),
   ])
 }
+#endif
 
 extension ArithmeticTests {
   static var all = testCase([
@@ -49,6 +83,8 @@ extension PropertyTests {
 }
 
 var testCases = [
+  ComplexTests.ElementaryFunctionTests.all,
+  RealTests.ElementaryFunctionTests.all,
   ElementaryFunctionChecks.all,
   IntegerExponentTests.all,
   ArithmeticTests.all,
@@ -59,6 +95,7 @@ var testCases = [
 extension DifferentiableTests {
   static var all = testCase([
     ("testComponentGetter", DifferentiableTests.testComponentGetter),
+    ("testInitializer", DifferentiableTests.testInitializer),
     ("testConjugate",  DifferentiableTests.testConjugate),
     ("testArithmetics", DifferentiableTests.testArithmetics),
   ])


### PR DESCRIPTION
This adds the newly added tests to the Windows tests and adds a
dependency on the Numerics module which is used as well to prevent any
race conditions.