### PR TITLE
Remove muladdf16 for now.

### DIFF
--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -172,10 +172,5 @@ extension Float16: Real {
     Float16(.logGamma(Float(x)))
   }
   #endif
-  
-  @_transparent
-  public static func _mulAdd(_ a: Float16, _ b: Float16, _ c: Float16) -> Float16 {
-    _numerics_muladdf16(a, b, c)
-  }
 }
 #endif

--- a/Sources/_NumericsShims/include/_NumericsShims.h
+++ b/Sources/_NumericsShims/include/_NumericsShims.h
@@ -384,12 +384,6 @@ HEADER_SHIM long double libm_lgammal(long double x, int *signp) {
 
 // MARK: - fast mul-add inlines
 /// a*b + c evaluated _either_ as two operations or fma, whichever is faster.
-HEADER_SHIM _Float16 _numerics_muladdf16(_Float16 a, _Float16 b, _Float16 c) {
-#pragma STDC FP_CONTRACT ON
-  return a*b + c;
-}
-
-/// a*b + c evaluated _either_ as two operations or fma, whichever is faster.
 HEADER_SHIM float _numerics_muladdf(float a, float b, float c) {
 #pragma STDC FP_CONTRACT ON
   return a*b + c;


### PR DESCRIPTION
The 5.2 clang doesn't like _Float16, even when unused in a header inline. Let's remove for now, since nothing needs it yet.