### PR TITLE
Exposes QuaternionModule as part of the Numerics module

### DIFF
--- a/Sources/Numerics/Numerics.swift
+++ b/Sources/Numerics/Numerics.swift
@@ -12,3 +12,4 @@
 // A module that re-exports the complete Swift Numerics public API.
 @_exported import RealModule
 @_exported import ComplexModule
+@_exported import QuaternionModule


### PR DESCRIPTION
As `import Numerics` should re-export the complete Swift Numerics public API, I have added the QuaternionModule to the list.