### PR TITLE
Swap availability for #if check on Float16.

### DIFF
--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -9,12 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if swift(>=5.3)
+#if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
 import _NumericsShims
 
 @available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-@available(macOS, unavailable)
-@available(macCatalyst, unavailable)
 extension Float16: Real {
   @_transparent
   public static func cos(_ x: Float16) -> Float16 {

--- a/Sources/_TestSupport/RealTestSupport.swift
+++ b/Sources/_TestSupport/RealTestSupport.swift
@@ -86,10 +86,8 @@ public protocol FixedWidthFloatingPoint: BinaryFloatingPoint
 where Exponent: FixedWidthInteger,
       RawSignificand: FixedWidthInteger { }
 
-#if swift(>=5.3)
+#if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
 @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
-@available(macOS, unavailable)
-@available(macCatalyst, unavailable)
 extension Float16: FixedWidthFloatingPoint { }
 #endif
 

--- a/Tests/RealTests/ElementaryFunctionChecks.swift
+++ b/Tests/RealTests/ElementaryFunctionChecks.swift
@@ -60,7 +60,7 @@ internal extension Real where Self: BinaryFloatingPoint {
 
 final class ElementaryFunctionChecks: XCTestCase {
   
-  #if swift(>=5.3) && !os(macOS)
+  #if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
   func testFloat16() {
     if #available(iOS 14.0, watchOS 14.0, tvOS 7.0, *) {
       Float16.elementaryFunctionChecks()

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -77,9 +77,8 @@ internal extension Real where Self: FixedWidthFloatingPoint {
   }
 }
 
-#if swift(>=5.3)
+#if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
 @available(iOS 14.0, watchOS 14.0, tvOS 7.0, *)
-@available(macOS, unavailable)
 extension Float16 {
   static func testIntegerExponent() {
     testIntegerExponentCommon()
@@ -174,8 +173,8 @@ extension Double {
 }
 
 final class IntegerExponentTests: XCTestCase {
-
-  #if swift(>=5.3) && !os(macOS)
+  
+  #if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
   func testFloat16() {
     Float16.testIntegerExponent()
   }

--- a/Tests/WindowsMain.swift
+++ b/Tests/WindowsMain.swift
@@ -32,7 +32,7 @@ extension RealTests.ApproximateEqualityTests {
   ])
 }
 
-#if swift(>=5.3)
+#if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
 extension ElementaryFunctionChecks {
   static var all = testCase([
     ("testFloat16", ElementaryFunctionChecks.testFloat16),
@@ -49,7 +49,7 @@ extension ElementaryFunctionChecks {
 }
 #endif
 
-#if swift(>=5.3)
+#if swift(>=5.3) && !(os(macOS) || os(iOS) && targetEnvironment(macCatalyst))
 extension IntegerExponentTests {
   static var all = testCase([
     ("testFloat16", IntegerExponentTests.testFloat16),


### PR DESCRIPTION
Xcode 12 on Catalina has Swift 5.3 but the macOS 10.15 SDK, which [breaks the conditionals around Float16](https://github.com/apple/swift-numerics/issues/156). Since the type is unconditionally unavailable on macOS, we can simply `#if`-out any Float16 extensions instead.