### PR TITLE
build: enable building `Numerics` on Darwin with CMake

### DIFF
--- a/Sources/Numerics/CMakeLists.txt
+++ b/Sources/Numerics/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(Numerics PROPERTIES
 # NOTE: generate the force load symbol to ensure that the import library is
 # generated on Windows for autolinking.
 target_compile_options(Numerics PUBLIC
-  -autolink-force-load
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:-autolink-force-load>
   # SR-12254: workaround for the swift compiler not properly tracking the force
   # load symbol when validating the TBD
   -Xfrontend -validate-tbd-against-ir=none)


### PR DESCRIPTION
The `-enable-force-autolink` flag is not supported on Darwin.
Fortunately, it is also unnecessary to work around the SR on Darwin.
Simply exclude the flag when targeting Darwin.