### PR TITLE
Remove .xcodesamplecode.plist, which prevents editing markdown from Xcode

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<array/>
-</plist>


### PR DESCRIPTION
This is kind of cool, but it prevents editing the markdown from Xcode (but not any other text editor).