### PR TITLE
Remove Real and Complex _libraries_; keep modules.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,7 @@ let package = Package(
   
   name: "swift-numerics",
   products: [
-    .library(name: "ComplexModule", targets: ["ComplexModule"]),
-    .library(name: "Numerics", targets: ["Numerics"]),
-    .library(name: "RealModule", targets: ["RealModule"]),
+    .library(name: "Numerics", targets: ["Numerics"])
   ],
   
   targets: [


### PR DESCRIPTION
These are vestigial, and not needed to support swift-pm.