### PR TITLE
Revert "Remove Real and Complex _libraries_; keep modules."

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
   
   name: "swift-numerics",
   products: [
-    .library(name: "Numerics", targets: ["Numerics"])
+    .library(name: "ComplexModule", targets: ["ComplexModule"]),
+    .library(name: "Numerics", targets: ["Numerics"]),
+    .library(name: "RealModule", targets: ["RealModule"]),
   ],
   
   targets: [


### PR DESCRIPTION
Reverts apple/swift-numerics#187

After discussing further with Karoy and Kyle, we decided that we want to keep these finer-grained library targets around to allow apps to control binary size when needed.