### PR TITLE
Explicitly exclude CMakeLists.txt and README.md files from all targets.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,8 @@
 
 import PackageDescription
 
+let excludedFilenames = ["CMakeLists.txt", "README.md"]
+
 let package = Package(
   
   name: "swift-numerics",
@@ -22,23 +24,76 @@ let package = Package(
   ],
   
   targets: [
-    // User-facing modules
-    .target(name: "ComplexModule", dependencies: ["RealModule"]),
-    .target(name: "IntegerUtilities", dependencies: []),
-    .target(name: "Numerics", dependencies: ["ComplexModule", "IntegerUtilities", "RealModule"]),
-    .target(name: "RealModule", dependencies: ["_NumericsShims"]),
+    // MARK: - Public API
+    .target(
+      name: "ComplexModule",
+      dependencies: ["RealModule"],
+      exclude: excludedFilenames
+    ),
     
-    // Implementation details
-    .target(name: "_NumericsShims", dependencies: []),
-    .target(name: "_TestSupport", dependencies: ["Numerics"]),
+    .target(
+      name: "IntegerUtilities",
+      dependencies: [],
+      exclude: excludedFilenames
+    ),
     
-    // Unit test bundles
-    .testTarget(name: "ComplexTests", dependencies: ["_TestSupport"]),
-    .testTarget(name: "IntegerUtilitiesTests", dependencies: ["IntegerUtilities"]),
-    .testTarget(name: "RealTests", dependencies: ["_TestSupport"]),
+    .target(
+      name: "Numerics",
+      dependencies: ["ComplexModule", "IntegerUtilities", "RealModule"],
+      exclude: excludedFilenames
+    ),
     
-    // Test executables
-    .target(name: "ComplexLog", dependencies: ["Numerics", "_TestSupport"], path: "Tests/Executable/ComplexLog"),
-    .target(name: "ComplexLog1p", dependencies: ["Numerics", "_TestSupport"], path: "Tests/Executable/ComplexLog1p")
+    .target(
+      name: "RealModule",
+      dependencies: ["_NumericsShims"],
+      exclude: excludedFilenames
+    ),
+    
+    // MARK: - Implementation details
+    .target(
+      name: "_NumericsShims",
+      dependencies: [],
+      exclude: excludedFilenames
+    ),
+    
+    .target(
+      name: "_TestSupport",
+      dependencies: ["Numerics"],
+      exclude: excludedFilenames
+    ),
+    
+    // MARK: - Unit test bundles
+    .testTarget(
+      name: "ComplexTests",
+      dependencies: ["_TestSupport"],
+      exclude: excludedFilenames
+    ),
+    
+    .testTarget(
+      name: "IntegerUtilitiesTests",
+      dependencies: ["IntegerUtilities"],
+      exclude: excludedFilenames
+    ),
+    
+    .testTarget(
+      name: "RealTests",
+      dependencies: ["_TestSupport"],
+      exclude: excludedFilenames
+    ),
+    
+    // MARK: - Test executables
+    .target(
+      name: "ComplexLog",
+      dependencies: ["Numerics", "_TestSupport"],
+      path: "Tests/Executable/ComplexLog",
+      exclude: excludedFilenames
+    ),
+    
+    .target(
+      name: "ComplexLog1p",
+      dependencies: ["Numerics", "_TestSupport"],
+      path: "Tests/Executable/ComplexLog1p",
+      exclude: excludedFilenames
+    )
   ]
 )


### PR DESCRIPTION
If/when we bump swift-tools-version to 5.3 or greater, swift-pm will start complaining about these, so let's explicitly exclude them now.