### PR TITLE
Add `isReal` to `Quaternion` and refine comments on `isPure`

### DIFF
--- a/Sources/QuaternionModule/Quaternion.swift
+++ b/Sources/QuaternionModule/Quaternion.swift
@@ -186,6 +186,7 @@ extension Quaternion {
   /// - `.isNormal`
   /// - `.isSubnormal`
   /// - `.isZero`
+  /// - `.isReal`
   /// - `.isPure`
   @_transparent
   public var isFinite: Bool {
@@ -206,6 +207,7 @@ extension Quaternion {
   /// - `.isFinite`
   /// - `.isSubnormal`
   /// - `.isZero`
+  /// - `.isReal`
   /// - `.isPure`
   @_transparent
   public var isNormal: Bool {
@@ -228,6 +230,7 @@ extension Quaternion {
   /// - `.isFinite`
   /// - `.isNormal`
   /// - `.isZero`
+  /// - `.isReal`
   /// - `.isPure`
   @_transparent
   public var isSubnormal: Bool {
@@ -243,13 +246,40 @@ extension Quaternion {
   /// - `.isFinite`
   /// - `.isNormal`
   /// - `.isSubnormal`
+  /// - `.isReal`
   /// - `.isPure`
   @_transparent
   public var isZero: Bool {
     components == .zero
   }
 
-  /// True if this value is only defined by the imaginary part (`real == .zero`)
+  /// True if this quaternion is real.
+  ///
+  /// A quaternion is real if *all* imaginary components are zero.
+  ///
+  /// See also:
+  /// -
+  /// - `.isFinite`
+  /// - `.isNormal`
+  /// - `.isSubnormal`
+  /// - `.isZero`
+  /// - `.isPure`
+  @_transparent
+  public var isReal: Bool {
+    imaginary == .zero
+  }
+
+  /// True if this quaternion is pure.
+  ///
+  /// A quaternion is pure if the real component is zero.
+  ///
+  /// See also:
+  /// -
+  /// - `.isFinite`
+  /// - `.isNormal`
+  /// - `.isSubnormal`
+  /// - `.isZero`
+  /// - `.isReal`
   @_transparent
   public var isPure: Bool {
     real.isZero

--- a/Tests/QuaternionTests/PropertyTests.swift
+++ b/Tests/QuaternionTests/PropertyTests.swift
@@ -34,6 +34,15 @@ final class PropertyTests: XCTestCase {
     XCTAssertEqual(Quaternion<T>.zero.length, .zero)
     XCTAssertEqual(Quaternion<T>(real: .zero, imaginary: -.zero).length, .zero)
     XCTAssertEqual(Quaternion<T>(real: -.zero, imaginary: -.zero).length, .zero)
+    // The properties of pure and real
+    XCTAssertTrue(Quaternion<T>.zero.isPure) // zero quaternion is both, pure...
+    XCTAssertTrue(Quaternion<T>.zero.isReal) // and real
+    XCTAssertFalse(Quaternion<T>(1).isPure)
+    XCTAssertTrue(Quaternion<T>(1).isReal)
+    XCTAssertTrue(Quaternion<T>(real: .zero, imaginary: 1, 0, 0).isPure)
+    XCTAssertFalse(Quaternion<T>(real: .zero, imaginary: 1, 0, 0).isReal)
+    XCTAssertFalse(Quaternion<T>(from: SIMD4(repeating: 1)).isPure)
+    XCTAssertFalse(Quaternion<T>(from: SIMD4(repeating: 1)).isReal)
   }
 
   func testProperties() {


### PR DESCRIPTION
This PR adds a computed property to `Quaternion` that allows to check if a quaternion is a real quaternion, i.e. a quaternion with an imaginary/vector term of **0** (zero). This complements the existing property `isPure`, which allows to check for pure quaternions, i.e. quaternions that have a real/scalar term of **0** (zero). Note that `isReal` and `isPure` are **not** mutually exclusive, as a zero quaternion (_[0,0]_) is both pure and real.

Additionally, it adds a small refinement to the header comment of `isPure`.