### PR TITLE
Remove big/little endiant distinction in representation of DoubleWidth

### DIFF
--- a/Sources/_TestSupport/DoubleWidth.swift
+++ b/Sources/_TestSupport/DoubleWidth.swift
@@ -47,11 +47,7 @@ public struct DoubleWidth<Base : FixedWidthInteger> {
   public typealias High = Base
   public typealias Low = Base.Magnitude
 
-#if _endian(big)
-  internal var _storage: (high: High, low: Low)
-#else
   internal var _storage: (low: Low, high: High)
-#endif
 
   /// The high part of the value.
   public var high: High {
@@ -68,11 +64,7 @@ public struct DoubleWidth<Base : FixedWidthInteger> {
   /// - Parameter value: The tuple to use as the source of the new instance's
   ///   high and low parts.
   public init(_ value: (high: High, low: Low)) {
-#if _endian(big)
-    self._storage = (high: value.0, low: value.1)
-#else
-    self._storage = (low: value.1, high: value.0)
-#endif
+    self._storage = (low: value.low, high: value.high)
   }
 
   // We expect users to invoke the public initializer above as demonstrated in


### PR DESCRIPTION
This doesn't really add anything that we need; it changes the in-memory layout, but that's effectively an implementation detail. We might as well simply pick one and simplify things.

This does mean that DoubleWidth types have a "weird" layout on big endian systems, but that doesn't really cause any problems for anything. This _would_ be a problem if we sunk these types into the standard library and wanted to bridge them to/from `__int128_t` and friends, because the representation wouldn't match. It's also trivial to revert this change, however, since it doesn't actually intrude into any operations, so let's keep things simple for now.