### PR TITLE
Minor documentation formatting cleanup.

### DIFF
--- a/Sources/ComplexModule/Complex+AlgebraicField.swift
+++ b/Sources/ComplexModule/Complex+AlgebraicField.swift
@@ -111,7 +111,7 @@ extension Complex: AlgebraicField {
   /// ```
   ///
   /// Error Bounds:
-  /// -
+  ///
   /// Unlike real types, when working with complex types, multiplying by the
   /// reciprocal instead of dividing cannot change the result. If the
   /// reciprocal is non-nil, the two computations are always equivalent.

--- a/Sources/ComplexModule/Complex+Numeric.swift
+++ b/Sources/ComplexModule/Complex+Numeric.swift
@@ -47,9 +47,7 @@ extension Complex: Numeric {
   /// - If `z` is zero, `z.magnitude` is `0`.
   /// - Otherwise, `z.magnitude` is finite and non-zero.
   ///
-  /// See also:
-  /// - `.length`
-  /// - `.lengthSquared`
+  /// See also `.length` and `.lengthSquared`.
   @_transparent
   public var magnitude: RealType {
     guard isFinite else { return .infinity }

--- a/Sources/ComplexModule/Complex.swift
+++ b/Sources/ComplexModule/Complex.swift
@@ -16,7 +16,7 @@ import RealModule
 /// TODO: introductory text on complex numbers
 ///
 /// Implementation notes:
-/// -
+///
 /// This type does not provide heterogeneous real/complex arithmetic,
 /// not even the natural vector-space operations like real * complex.
 /// There are two reasons for this choice: first, Swift broadly avoids
@@ -105,11 +105,7 @@ extension Complex {
 extension Complex {
   /// The imaginary unit.
   ///
-  /// See also:
-  /// -
-  /// - .zero
-  /// - .one
-  /// - .infinity
+  /// See also `.zero`, `.one` and `.infinity`.
   @_transparent
   public static var i: Complex {
     Complex(0, 1)
@@ -117,11 +113,7 @@ extension Complex {
   
   /// The point at infinity.
   ///
-  /// See also:
-  /// -
-  /// - .zero
-  /// - .one
-  /// - .i
+  /// See also `.zero`, `.one` and `.i`.
   @_transparent
   public static var infinity: Complex {
     Complex(.infinity, 0)
@@ -131,11 +123,7 @@ extension Complex {
   ///
   /// A complex value is finite if neither component is an infinity or nan.
   ///
-  /// See also:
-  /// -
-  /// - `.isNormal`
-  /// - `.isSubnormal`
-  /// - `.isZero`
+  /// See also `.isNormal`, `.isSubnormal` and `.isZero`.
   @_transparent
   public var isFinite: Bool {
     x.isFinite && y.isFinite
@@ -148,10 +136,7 @@ extension Complex {
   /// one of the components is normal if its exponent allows a full-precision
   /// representation.
   ///
-  /// See also:
-  /// - `.isFinite`
-  /// - `.isSubnormal`
-  /// - `.isZero`
+  /// See also `.isFinite`, `.isSubnormal` and `.isZero`.
   @_transparent
   public var isNormal: Bool {
     isFinite && (x.isNormal || y.isNormal)
@@ -163,10 +148,7 @@ extension Complex {
   /// When the result of a computation is subnormal, underflow has occurred and
   /// the result generally does not have full precision.
   ///
-  /// See also:
-  /// - `.isFinite`
-  /// - `.isNormal`
-  /// - `.isZero`
+  /// See also `.isFinite`, `.isNormal` and `.isZero`.
   @_transparent
   public var isSubnormal: Bool {
     isFinite && !isNormal && !isZero
@@ -177,11 +159,7 @@ extension Complex {
   /// A complex number is zero if *both* the real and imaginary components
   /// are zero.
   ///
-  /// See also:
-  /// -
-  /// - `.isFinite`
-  /// - `.isNormal`
-  /// - `.isSubnormal`
+  /// See also `.isFinite`, `.isNormal` and `isSubnormal`.
   @_transparent
   public var isZero: Bool {
     x == 0 && y == 0

--- a/Sources/ComplexModule/Polar.swift
+++ b/Sources/ComplexModule/Polar.swift
@@ -31,16 +31,10 @@ extension Complex {
   /// a representable result.
   ///
   /// Edge cases:
-  /// -
-  /// If a complex value is not finite, its `.length` is `infinity`.
+  /// - If a complex value is not finite, its `.length` is `infinity`.
   ///
-  /// See also:
-  /// -
-  /// - `.magnitude`
-  /// - `.lengthSquared`
-  /// - `.phase`
-  /// - `.polar`
-  /// - `init(r:θ:)`
+  /// See also `.magnitude`, `.lengthSquared`, `.phase`, `.polar`
+  /// and `init(r:θ:)`.
   @_transparent
   public var length: RealType {
     let naive = lengthSquared
@@ -69,10 +63,7 @@ extension Complex {
   /// For many cases, `.magnitude` can be used instead, which is similarly
   /// cheap to compute and always returns a representable value.
   ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.magnitude`
+  /// See also `.length` and `.magnitude`.
   @_transparent
   public var lengthSquared: RealType {
     x*x + y*y
@@ -88,14 +79,9 @@ extension Complex {
   /// and `nan` is returned.
   ///
   /// Edge cases:
-  /// -
-  /// If the complex value is zero or non-finite, phase is `nan`.
+  /// - If the complex value is zero or non-finite, phase is `nan`.
   ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.polar`
-  /// - `init(r:θ:)`
+  /// See also `.length`, `.polar` and `init(r:θ:)`.
   @inlinable
   public var phase: RealType {
     guard isFinite && !isZero else { return .nan }
@@ -105,15 +91,10 @@ extension Complex {
   /// The length and phase (or polar coordinates) of this value.
   ///
   /// Edge cases:
-  /// -
-  /// If the complex value is zero or non-finite, phase is `.nan`.
-  /// If the complex value is non-finite, length is `.infinity`.
+  /// - If the complex value is zero or non-finite, phase is `.nan`.
+  /// - If the complex value is non-finite, length is `.infinity`.
   ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.phase`
-  /// - `init(r:θ:)`
+  /// See also: `.length`, `.phase` and `init(r:θ:)`.
   public var polar: (length: RealType, phase: RealType) {
     (length, phase)
   }
@@ -121,7 +102,6 @@ extension Complex {
   /// Creates a complex value specified with polar coordinates.
   ///
   /// Edge cases:
-  /// -
   /// - Negative lengths are interpreted as reflecting the point through the
   ///   origin, i.e.:
   ///   ```
@@ -137,11 +117,7 @@ extension Complex {
   ///   ```
   /// - Otherwise, `θ` must be finite, or a precondition failure occurs.
   ///
-  /// See also:
-  /// -
-  /// - `.length`
-  /// - `.phase`
-  /// - `.polar`
+  /// See also `.length`, `.phase` and `.polar`.
   @inlinable
   public init(length: RealType, phase: RealType) {
     if phase.isFinite {

--- a/Sources/RealModule/AlgebraicField.swift
+++ b/Sources/RealModule/AlgebraicField.swift
@@ -37,12 +37,7 @@
 /// If a type `T` conforms to the `Real` protocol, then `T` and `Complex<T>`
 /// both conform to `AlgebraicField`.
 ///
-/// See Also:
-/// -
-/// - Real
-/// - SignedNumeric
-/// - Numeric
-/// - AdditiveArithmetic
+/// See also `Real`, `SignedNumeric`, `Numeric` and `AdditiveArithmetic`.
 ///
 /// [field]: https://en.wikipedia.org/wiki/Field_(mathematics)
 public protocol AlgebraicField: SignedNumeric {

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -28,8 +28,7 @@ extension Numeric where Magnitude: FloatingPoint {
   /// is not suitable for all use cases.
   ///
   /// Mathematical Properties:
-  /// ------------------------
-  /// 
+  ///
   /// - `isApproximatelyEqual(to:relativeTolerance:norm:)` is _reflexive_ for
   ///   non-exceptional values (such as NaN).
   ///
@@ -51,9 +50,7 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   so long as no underflow or overflow has occured, and no exceptional
   ///   value is produced by the scaling.
   ///
-  /// See Also:
-  /// -------
-  /// - `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:norm:])`
+  /// See also `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:norm:])`.
   ///
   /// - Parameters:
   ///
@@ -98,7 +95,6 @@ extension Numeric where Magnitude: FloatingPoint {
   /// where `scale` is `max(self.magnitude, other.magnitude)`.
   ///
   /// Mathematical Properties:
-  /// ------------------------
   ///
   /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:)`
   ///   is _reflexive_ for non-exceptional values (such as NaN).
@@ -118,9 +114,7 @@ extension Numeric where Magnitude: FloatingPoint {
   ///   to `a` is _convex_. (Under the assumption that `norm` implements a
   ///   valid norm, which cannot be checked by this function.)
   ///
-  /// See Also:
-  /// -------
-  /// - `isApproximatelyEqual(to:[relativeTolerance:])`
+  /// See also `isApproximatelyEqual(to:[relativeTolerance:])`.
   ///
   /// - Parameters:
   ///
@@ -170,7 +164,6 @@ extension AdditiveArithmetic {
   /// where `scale` is `max(norm(self), norm(other))`.
   ///
   /// Mathematical Properties:
-  /// ------------------------
   ///
   /// - `isApproximatelyEqual(to:absoluteTolerance:relativeTolerance:norm:)`
   ///   is _reflexive_ for non-exceptional values (such as NaN).
@@ -191,10 +184,8 @@ extension AdditiveArithmetic {
   ///   to `a` is _convex_ (under the assumption that `norm` implements a
   ///   valid norm, which cannot be checked by this function or a protocol).
   ///
-  /// See Also:
-  /// -------
-  /// - `isApproximatelyEqual(to:[relativeTolerance:norm:])`
-  /// - `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:])`
+  /// See also `isApproximatelyEqual(to:[relativeTolerance:norm:])` and
+  /// `isApproximatelyEqual(to:absoluteTolerance:[relativeTolerance:])`.
   ///
   /// - Parameters:
   ///

--- a/Sources/RealModule/AugmentedArithmetic.swift
+++ b/Sources/RealModule/AugmentedArithmetic.swift
@@ -28,7 +28,7 @@ extension Augmented {
   /// This operation is sometimes called "twoProd" or "twoProduct".
   ///
   /// Edge Cases:
-  /// -
+  ///
   /// - `head` is always the IEEE 754 product `a * b`.
   /// - If `head` is not finite, `tail` is unspecified and should not be
   ///   interpreted as having any meaning (it may be `NaN` or `infinity`).
@@ -39,7 +39,7 @@ extension Augmented {
   /// - If `head` is zero, `tail` is also a zero with unspecified sign.
   ///
   /// Postconditions:
-  /// -
+  ///
   /// - If `head` is normal, then `abs(tail) < head.ulp`.
   ///   Assuming IEEE 754 default rounding, `abs(tail) <= head.ulp/2`.
   /// - If both `head` and `tail` are normal, then `a * b` is exactly
@@ -61,8 +61,7 @@ extension Augmented {
   /// value.
   ///
   /// Unlike `Augmented.product(a, b)`, the rounding error of a sum can
-  /// never underflow. However, it may not be exactly representable when
-  /// `a` and `b` differ widely in magnitude.
+  /// never underflow.
   ///
   /// This operation is sometimes called ["fastTwoSum"].
   ///
@@ -71,19 +70,19 @@ extension Augmented {
   ///   - b: The summand with smaller magnitude.
   ///
   /// Preconditions:
-  /// -
+  ///
   /// - `large.magnitude` must not be smaller than `small.magnitude`.
   ///   They may be equal, or one or both may be `NaN`.
   ///   This precondition is only enforced in debug builds.
   ///
   /// Edge Cases:
-  /// -
+  ///
   /// - `head` is always the IEEE 754 sum `a + b`.
   /// - If `head` is not finite, `tail` is unspecified and should not be
   ///   interpreted as having any meaning (it may be `NaN` or `infinity`).
   ///
   /// Postconditions:
-  /// -
+  ///
   /// - If `head` is normal, then `abs(tail) < head.ulp`.
   ///   Assuming IEEE 754 default rounding, `abs(tail) <= head.ulp/2`.
   ///
@@ -112,8 +111,7 @@ extension Augmented {
   /// over this function; as it faster to calculate.
   ///
   /// Unlike `Augmented.product(a, b)`, the rounding error of a sum can
-  /// never underflow. However, it may not be exactly representable when
-  /// `a` and `b` differ widely in magnitude.
+  /// never underflow.
   ///
   /// This operation is sometimes called ["twoSum"].
   ///
@@ -122,13 +120,13 @@ extension Augmented {
   ///   - b: The other summand
   ///
   /// Edge Cases:
-  /// -
+  ///
   /// - `head` is always the IEEE 754 sum `a + b`.
   /// - If `head` is not finite, `tail` is unspecified and should not be
   ///   interpreted as having any meaning (it may be `NaN` or `infinity`).
   ///
   /// Postconditions:
-  /// -
+  /// 
   /// - If `head` is normal, then `abs(tail) < head.ulp`.
   ///   Assuming IEEE 754 default rounding, `abs(tail) <= head.ulp/2`.
   ///

--- a/Sources/RealModule/ElementaryFunctions.swift
+++ b/Sources/RealModule/ElementaryFunctions.swift
@@ -47,7 +47,7 @@
 /// protocol that you will want to use most often for generic code.
 ///
 /// See Also:
-/// -
+///
 /// - `RealFunctions`
 /// - `Real`
 ///
@@ -56,11 +56,8 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// The [exponential function][wiki] e^x whose base `e` is the base of the
   /// natural logarithm.
   ///
-  /// See also:
-  /// -
-  /// - `expMinusOne()`
-  /// - `exp2()` (for types conforming to `RealFunctions`)
-  /// - `exp10()` (for types conforming to `RealFunctions`)
+  /// See also `expMinusOne()`, as well as `exp2()` and `exp10()`
+  /// defined for types conforming to `RealFunctions`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Exponential_function
   static func exp(_ x: Self) -> Self
@@ -82,11 +79,8 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// This re-written expression delivers an accurate result for all values
   /// of `x`, not just for small values.
   ///
-  /// See also:
-  /// -
-  /// - `exp()`
-  /// - `exp2()` (for types conforming to `RealFunctions`)
-  /// - `exp10()` (for types conforming to `RealFunctions`)
+  /// See also `exp()`, as well as `exp2()` and `exp10()` defined for types
+  /// conforming to `RealFunctions`.
   static func expMinusOne(_ x: Self) -> Self
   
   /// The [hyperbolic cosine][wiki] of `x`.
@@ -96,11 +90,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///                2
   /// ```
   ///
-  /// See also:
-  /// -
-  /// - `sinh()`
-  /// - `tanh()`
-  /// - `acosh()`
+  /// See also `sinh()`, `tanh()` and `acosh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Hyperbolic_function
   static func cosh(_ x: Self) -> Self
@@ -112,11 +102,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///                2
   /// ```
   ///
-  /// See also:
-  /// -
-  /// - `cosh()`
-  /// - `tanh()`
-  /// - `asinh()`
+  /// See also `cosh()`, `tanh()` and `asinh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Hyperbolic_function
   static func sinh(_ x: Self) -> Self
@@ -128,11 +114,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///            cosh(x)
   /// ```
   ///
-  /// See also:
-  /// -
-  /// - `cosh()`
-  /// - `sinhh()`
-  /// - `atanh()`
+  /// See also `cosh()`, `sinh()` and `atanh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Hyperbolic_function
   static func tanh(_ x: Self) -> Self
@@ -141,11 +123,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///
   /// For real types, `x` may be interpreted as an angle measured in radians.
   ///
-  /// See also:
-  /// -
-  /// - `sin()`
-  /// - `tan()`
-  /// - `acos()`
+  /// See also `sin()`, `tan()` and `acos()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Cosine
   static func cos(_ x: Self) -> Self
@@ -155,11 +133,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///
   /// For real types, `x` may be interpreted as an angle measured in radians.
   ///
-  /// See also:
-  /// -
-  /// - `cos()`
-  /// - `tan()`
-  /// - `asin()`
+  /// See also `cos()`, `tan()` and `asin()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Sine
   static func sin(_ x: Self) -> Self
@@ -168,49 +142,31 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   ///
   /// For real types, `x` may be interpreted as an angle measured in radians.
   ///
-  /// See also:
-  /// -
-  /// - `cos()`
-  /// - `sin()`
-  /// - `atan()`
-  /// - `atan2(y:x:)` (for types conforming to `RealFunctions`)
-  /// ```
-  ///           sin(x)
-  /// tan(x) = --------
-  ///           cos(x)
-  /// ```
+  /// See also `cos()`, `sin()` and `atan()`, as well as `atan2(y:x:)` for
+  /// types that conform to `RealFunctions`.
+  ///
   /// [wiki]: https://en.wikipedia.org/wiki/Tangent
   static func tan(_ x: Self) -> Self
   
   /// The [natural logarithm][wiki] of `x`.
   ///
-  /// See also:
-  /// -
-  /// - `log(onePlus:)`
-  /// - `log2()` (for types conforming to `RealFunctions`)
-  /// - `log10()` (for types conforming to `RealFunctions`)
+  /// See also `log(onePlus:)`, as well as `log2()` and `log10()` for types
+  /// that conform to `RealFunctions`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Logarithm
   static func log(_ x: Self) -> Self
   
   /// log(1 + x), computed in such a way as to maintain accuracy for small x.
   ///
-  /// See also:
-  /// -
-  /// - `log()`
-  /// - `log2()` (for types conforming to `RealFunctions`)
-  /// - `log10()` (for types conforming to `RealFunctions`)
+  /// See also `log()`, as well as `log2()` and `log10()` for types
+  /// that conform to `RealFunctions`.
   static func log(onePlus x: Self) -> Self
   
   /// The [inverse hyperbolic cosine][wiki] of `x`.
   /// ```
   /// cosh(acosh(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `asinh()`
-  /// - `atanh()`
-  /// - `cosh()`
+  /// See also `asinh()`, `atanh()` and `cosh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_hyperbolic_function
   static func acosh(_ x: Self) -> Self
@@ -219,11 +175,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// ```
   /// sinh(asinh(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `acosh()`
-  /// - `atanh()`
-  /// - `sinh()`
+  /// See also `acosh()`, `atanh()` and `sinh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_hyperbolic_function
   static func asinh(_ x: Self) -> Self
@@ -232,11 +184,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// ```
   /// tanh(atanh(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `acosh()`
-  /// - `asinh()`
-  /// - `tanh()`
+  /// See also `acosh()`, `asinh()` and `tanh()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_hyperbolic_function
   static func atanh(_ x: Self) -> Self
@@ -248,11 +196,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// ```
   /// cos(acos(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `asin()`
-  /// - `atan()`
-  /// - `cos()`
+  /// See also `asin()`, `atan()` and `cos()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_trigonometric_functions
   static func acos(_ x: Self) -> Self
@@ -264,11 +208,7 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// ```
   /// sin(asin(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `acos()`
-  /// - `atan()`
-  /// - `sin()`
+  /// See also `acos()`, `atan()` and `sin()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_trigonometric_functions
   static func asin(_ x: Self) -> Self
@@ -280,50 +220,34 @@ public protocol ElementaryFunctions: AdditiveArithmetic {
   /// ```
   /// tan(atan(x)) ≅ x
   /// ```
-  /// See also:
-  /// -
-  /// - `acos()`
-  /// - `asin()`
-  /// - `atan2()` (for types conforming to `RealFunctions`)
-  /// - `tan()`
+  /// See also `acos()`, `asin()` and `tan()`, as well as `atan2(y:x:)` for
+  /// types that conform to `RealArithmetic`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Inverse_trigonometric_functions
   static func atan(_ x: Self) -> Self
   
   /// exp(y * log(x)) computed with additional internal precision.
   ///
-  /// See also:
-  /// -
-  /// - `sqrt()`
-  /// - `root()`
+  /// See also `sqrt()` and `root()`.
   ///
   static func pow(_ x: Self, _ y: Self) -> Self
   
   /// `x` raised to the nth power.
   ///
-  /// See also:
-  /// -
-  /// - `sqrt()`
-  /// - `root()`
+  /// See also `sqrt()` and `root()`.
   ///
   static func pow(_ x: Self, _ n: Int) -> Self
   
   /// The [square root][wiki] of `x`.
   ///
-  /// See also:
-  /// -
-  /// - `pow()`
-  /// - `root()`
+  /// See also `pow()` and `root()`.
   ///
   /// [wiki]: https://en.wikipedia.org/wiki/Square_root
   static func sqrt(_ x: Self) -> Self
   
   /// The nth root of `x`.
   ///
-  /// See also:
-  /// -
-  /// - `pow()`
-  /// - `sqrt()`
+  /// See also `pow()` and `sqrt()`.
   ///
   static func root(_ x: Self, _ n: Int) -> Self
 }

--- a/Sources/RealModule/Real.swift
+++ b/Sources/RealModule/Real.swift
@@ -23,11 +23,7 @@
 ///   return 1/(1 + .exp(-x))
 /// }
 /// ```
-/// See Also:
-/// -
-/// - `ElementaryFunctions`
-/// - `RealFunctions`
-/// - `AlgebraicField`
+/// See also `ElementaryFunctions`, `RealFunctions` and `AlgebraicField`.
 public protocol Real: FloatingPoint, RealFunctions, AlgebraicField {
 }
 
@@ -44,9 +40,7 @@ extension Real {
   
   /// cos(x) - 1, computed in such a way as to maintain accuracy for small x.
   ///
-  /// See also:
-  /// -
-  /// - `ElementaryFunctions.expMinusOne()`
+  /// See also `ElementaryFunctions.expMinusOne()`.
   @_transparent
   public static func cosMinusOne(_ x: Self) -> Self {
     let sinxOver2 = sin(x/2)
@@ -124,7 +118,7 @@ extension Real {
   /// ```
   ///
   /// Error Bounds:
-  /// -
+  ///
   /// Multiplying by the reciprocal instead of dividing will slightly
   /// perturb results. For example `5.0 / 3` is 1.6666666666666667, but
   /// `5.0 * 3.reciprocal!` is 1.6666666666666665.

--- a/Sources/RealModule/RealFunctions.swift
+++ b/Sources/RealModule/RealFunctions.swift
@@ -12,45 +12,27 @@
 public protocol RealFunctions: ElementaryFunctions {
   /// `atan(y/x)`, with sign selected according to the quadrant of `(x, y)`.
   ///
-  /// See also:
-  /// -
-  /// - `atan()`
+  /// See also `atan()`.
   static func atan2(y: Self, x: Self) -> Self
   
   /// The error function evaluated at `x`.
   ///
-  /// See also:
-  /// -
-  /// - `erfc()`
+  /// See also `erfc()`.
   static func erf(_ x: Self) -> Self
   
   /// The complimentary error function evaluated at `x`.
   ///
-  /// See also:
-  /// -
-  /// - `erf()`
+  /// See also `erf()`.
   static func erfc(_ x: Self) -> Self
   
   /// 2^x
   ///
-  /// See also:
-  /// -
-  /// - `exp()`
-  /// - `expMinusOne()`
-  /// - `exp10()`
-  /// - `log2()`
-  /// - `pow()`
+  /// See also `exp()`, `expMinusOne()`, `exp10()`, `log2()` and `pow()`.
   static func exp2(_ x: Self) -> Self
   
   /// 10^x
   ///
-  /// See also:
-  /// -
-  /// - `exp()`
-  /// - `expMinusOne()`
-  /// - `exp2()`
-  /// - `log10()`
-  /// - `pow()`
+  /// See also `exp()`, `expMinusOne()`, `exp2()`, `log10()` and `pow()`.
   static func exp10(_ x: Self) -> Self
   
   /// `sqrt(x*x + y*y)`, computed in a manner that avoids spurious overflow or
@@ -59,30 +41,17 @@ public protocol RealFunctions: ElementaryFunctions {
   
   /// The gamma function Γ(x).
   ///
-  /// See also:
-  /// -
-  /// - `logGamma()`
-  /// - `signGamma()`
+  /// See also `logGamma()` and `signGamma()`.
   static func gamma(_ x: Self) -> Self
   
   /// The base-2 logarithm of `x`.
   ///
-  /// See also:
-  /// -
-  /// - `exp2()`
-  /// - `log()`
-  /// - `log(onePlus:)`
-  /// - `log10()`
+  /// See also `exp2()`, `log()`, `log(onePlus:)` and `log10()`.
   static func log2(_ x: Self) -> Self
   
   /// The base-10 logarithm of `x`.
   ///
-  /// See also:
-  /// -
-  /// - `exp10()`
-  /// - `log()`
-  /// - `log(onePlus:)`
-  /// - `log2()`
+  /// See also: `exp10()`, `log()`, `log(onePlus:)` and `log2()`.
   static func log10(_ x: Self) -> Self
   
 #if !os(Windows)
@@ -90,10 +59,7 @@ public protocol RealFunctions: ElementaryFunctions {
   ///
   /// Not available on Windows targets.
   ///
-  /// See also:
-  /// -
-  /// - `gamma()`
-  /// - `signGamma()`
+  /// See also `gamma()` and `signGamma()`.
   static func logGamma(_ x: Self) -> Self
   
   /// The sign of the gamma function, Γ(x).
@@ -107,10 +73,7 @@ public protocol RealFunctions: ElementaryFunctions {
   ///
   /// Not available on Windows targets.
   ///
-  /// See also:
-  /// -
-  /// - `gamma()`
-  /// - `logGamma()`
+  /// See also `gamma()` and `logGamma()`.
   static func signGamma(_ x: Self) -> FloatingPointSign
 #endif
   


### PR DESCRIPTION
Xcode changed how it parses doc comments like

> Header
> -
> - bulleted list

so that now they simply get dropped on the floor. Remove this pattern from our doc comments.