### PR TITLE
Link math library on Android too

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
     .target(
       name: "_NumericsShims",
       exclude: excludedFilenames,
-      linkerSettings: [.linkedLibrary("m", .when(platforms: [.linux]))]
+      linkerSettings: [.linkedLibrary("m", .when(platforms: [.linux, .android]))]
     ),
     
     .target(


### PR DESCRIPTION
#225 broke my [Android CI](https://github.com/buttaface/swift-android-sdk/runs/5869303105?check_suite_focus=true#step:15:84), as it didn't include Android.