### PR TITLE
Fix broken link to `IntegerUtilities` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Questions about how to use Swift Numerics modules, or issues that are not clearl
 
 1. [`RealModule`](Sources/RealModule/README.md)
 2. [`ComplexModule`](Sources/ComplexModule/README.md)
-3. [`IntegerUtilities`](Sources/IntegerUtilties/README.md) (on main only, not yet present in a released tag)
+3. [`IntegerUtilities`](Sources/IntegerUtilities/README.md) (on main only, not yet present in a released tag)
 
 ## Future expansion
 


### PR DESCRIPTION
Fixes a broken link to the README.md  of `IntegerUtilities` in the Modules section of the project README.md