### PR TITLE
Add missing import required to use a conformance

### DIFF
--- a/Sources/_TestSupport/Error.swift
+++ b/Sources/_TestSupport/Error.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import ComplexModule
+import RealModule
 
 public func relativeError(_ tst: Float, _ ref: Double) -> Double {
   let scale = max(ref.magnitude, Double(Float.leastNormalMagnitude))


### PR DESCRIPTION
A new compiler check (https://github.com/apple/swift/pull/60008) reports a missing import for a conformance used in API. The compiler was only seeing the conformance because it was imported implicitly, via a different local file or module.

```
Sources/_TestSupport/Error.swift:21:13: error: cannot use conformance of 'Float' to 'Real' here; 'RealModule' was not imported by this file
public func componentwiseError(_ tst: Complex<Float>, _ ref: Complex<Double>) -> Double {
```

 Address this issue in the project by adding the missing import.