### PR TITLE
Replace `some BinaryInteger` with an explicit generic parameter.

### DIFF
--- a/Sources/IntegerUtilities/SaturatingArithmetic.swift
+++ b/Sources/IntegerUtilities/SaturatingArithmetic.swift
@@ -158,8 +158,8 @@ extension FixedWidthInteger {
   ///   and if negative a right shift.
   ///   - rounding rule: the direction in which to round if `count` is negative.
   @_transparent
-  public func shiftedWithSaturation(
-    leftBy count: some BinaryInteger,
+  public func shiftedWithSaturation<Count: BinaryInteger>(
+    leftBy count: Count,
     rounding rule: RoundingRule = .down
   ) -> Self {
     self.shiftedWithSaturation(leftBy: Int(clamping: count), rounding: rule)

--- a/Sources/IntegerUtilities/ShiftWithRounding.swift
+++ b/Sources/IntegerUtilities/ShiftWithRounding.swift
@@ -188,8 +188,8 @@ extension BinaryInteger {
   ///     a.shifted(rightBy: count, rounding: rule)
   ///     a.divided(by: 1 << count, rounding: rule)
   @_transparent
-  public func shifted(
-    rightBy count: some BinaryInteger,
+  public func shifted<Count: BinaryInteger>(
+    rightBy count: Count,
     rounding rule: RoundingRule = .down
   ) -> Self {
     self.shifted(rightBy: Int(clamping: count), rounding: rule)


### PR DESCRIPTION
For compatibility with pre-Swift-5.7 language versions.