### PR TITLE
[_TestSupport] Fix DoubleWidth think-o that trips an assert

### DIFF
--- a/Sources/_TestSupport/DoubleWidth.swift
+++ b/Sources/_TestSupport/DoubleWidth.swift
@@ -735,11 +735,12 @@ extension DoubleWidth : UnsignedInteger where Base : UnsignedInteger {
 
     // Left shift both rhs and lhs, then divide and right shift the remainder.
     let shift = rhs.leadingZeroBitCount
+    let high = (lhs >> (Magnitude.bitWidth &- shift)).low
     let rhs = rhs &<< shift
-    let high = (lhs &>> (Magnitude.bitWidth &- shift)).low
     let lhs = lhs &<< shift
-    let (quotient, remainder) =
-      Magnitude._divide((high, lhs.high, lhs.low), by: rhs)
+    let (quotient, remainder) = high == (0 as Low)
+      ? (1, lhs &- rhs)
+      : Magnitude._divide((high, lhs.high, lhs.low), by: rhs)
     return (Magnitude(0, quotient), remainder &>> shift)
   }
 }

--- a/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
+++ b/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
@@ -129,6 +129,22 @@ final class DoubleWidthTests: XCTestCase {
 
     XCTAssertEqual(x % 3, 1)
     XCTAssertEqual(x % y, x)
+
+    do {
+      let lhs = _UInt16((high: 0b0011_0000, low: 0))
+      let rhs = _UInt16((high: 0b0010_0000, low: 0))
+      XCTAssertEqual(lhs % rhs, 4096)
+    }
+    do {
+      let lhs = _UInt128((high: 0xa0c7d7165cf01386, low: 0xbf3f66a93056143f))
+      let rhs = _UInt128((high: 0x9ac3a19b1e7d6b83, low: 0x513929792d588736))
+      XCTAssertEqual(String(lhs % rhs), "7997221894243298914179865336050715913")
+    }
+    do {
+      let lhs = _UInt128((high: 0xea8a9116b7af33b7, low: 0x3d9d6779ddd22ca3))
+      let rhs = _UInt128((high: 0xc3673efc7f1f37cc, low: 0x312f661057d0ba94))
+      XCTAssertEqual(String(lhs % rhs), "52023287460685389410162512181093036559")
+    }
   }
 
   func testArithmetic_Signed() {

--- a/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
+++ b/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
@@ -145,6 +145,18 @@ final class DoubleWidthTests: XCTestCase {
       let rhs = _UInt128((high: 0xc3673efc7f1f37cc, low: 0x312f661057d0ba94))
       XCTAssertEqual(String(lhs % rhs), "52023287460685389410162512181093036559")
     }
+    do {
+      let lhs = _UInt256("2369676578372158364766242369061213561181961479062237766620")!
+      let rhs = _UInt256("102797312405202436815976773795958969482")!
+      XCTAssertEqual(String(lhs / rhs), "23051931251193218442")
+    }
+    do {
+      let lhs = _UInt256("96467201117289166187766181030232879447148862859323917044548749804018359008044")!
+      let rhs = _UInt256("4646260627574879223760172113656436161581617773435991717024")!
+      XCTAssertEqual(String(lhs / rhs), "20762331011904583253")
+    }
+    
+    XCTAssertTrue((0xff01 as _UInt16).multipliedFullWidth(by: 0x101) == (high: 256, low: 1))
   }
 
   func testArithmetic_Signed() {


### PR DESCRIPTION
If `lhs` and `rhs` have the same number of leading zero bits (and we know `rhs < lhs`), then we can't call `_divide` to divide a triple-width magnitude by a double-width magnitude (this trips the assert on line 634), but rather we know that the quotient is one. Additionally, we must use `>>` instead of `&>>` when computing the high word because in this scenario the leading zero bits may be zero.

Since it turns out there's more than one calling site for `_divide` that doesn't ensure the invariant asserted on line 634, we should actually deal with this in one place by replacing the assertion with a `guard` that handles the special case.

Additionally, fix a third think-o related to full-width multiplication where a carry isn't accounted for, causing unintended overflow with certain inputs.

This type now gives correct output verified for addition/subtraction/multiplication/nonzero-division-with-overflow for every pair of 16-bit unsigned integers using `DoubleWidth<DoubleWidth<UInt4>>` (with a custom `UInt4` implementation).

Resolves https://github.com/apple/swift-numerics/issues/272