### PR TITLE
Move the -lm link command to RealModule (from _NumericsShims).

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,16 +46,16 @@ let package = Package(
     .target(
       name: "RealModule",
       dependencies: ["_NumericsShims"],
-      exclude: excludedFilenames
+      exclude: excludedFilenames,
+      linkerSettings: [
+        .linkedLibrary("m", .when(platforms: [.linux, .android]))
+      ]
     ),
     
     // MARK: - Implementation details
     .target(
       name: "_NumericsShims",
-      exclude: excludedFilenames,
-      linkerSettings: [
-        .linkedLibrary("m", .when(platforms: [.linux, .android]))
-      ]
+      exclude: excludedFilenames
     ),
     
     .target(

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -46,14 +46,16 @@ let package = Package(
     .target(
       name: "RealModule",
       dependencies: ["_NumericsShims"],
-      exclude: excludedFilenames
+      exclude: excludedFilenames,
+      linkerSettings: [
+        .linkedLibrary("m", .when(platforms: [.linux, .android]))
+      ]
     ),
     
     // MARK: - Implementation details
     .target(
       name: "_NumericsShims",
-      exclude: excludedFilenames,
-      linkerSettings: [.linkedLibrary("m", .when(platforms: [.linux, .android]))]
+      exclude: excludedFilenames
     ),
     
     .target(


### PR DESCRIPTION
Hopefully this resolves some niche link errors that we've seen sporadically.