### PR TITLE
Update license headers and copyright notices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/CMakeLists.txt
+++ b/Sources/ComplexModule/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+AdditiveArithmetic.swift
+++ b/Sources/ComplexModule/Complex+AdditiveArithmetic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+AlgebraicField.swift
+++ b/Sources/ComplexModule/Complex+AlgebraicField.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+Codable.swift
+++ b/Sources/ComplexModule/Complex+Codable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+ElementaryFunctions.swift
+++ b/Sources/ComplexModule/Complex+ElementaryFunctions.swift
@@ -1,12 +1,11 @@
 //===--- Complex+ElementaryFunctions.swift --------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Sources/ComplexModule/Complex+Hashable.swift
+++ b/Sources/ComplexModule/Complex+Hashable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+IntegerLiteral.swift
+++ b/Sources/ComplexModule/Complex+IntegerLiteral.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+Numeric.swift
+++ b/Sources/ComplexModule/Complex+Numeric.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex+StringConvertible.swift
+++ b/Sources/ComplexModule/Complex+StringConvertible.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Complex.swift
+++ b/Sources/ComplexModule/Complex.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Polar.swift
+++ b/Sources/ComplexModule/Polar.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/ComplexModule/Scale.swift
+++ b/Sources/ComplexModule/Scale.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/CMakeLists.txt
+++ b/Sources/IntegerUtilities/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/DivideWithRounding.swift
+++ b/Sources/IntegerUtilities/DivideWithRounding.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/GCD.swift
+++ b/Sources/IntegerUtilities/GCD.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/Rotate.swift
+++ b/Sources/IntegerUtilities/Rotate.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/RoundingRule.swift
+++ b/Sources/IntegerUtilities/RoundingRule.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/SaturatingArithmetic.swift
+++ b/Sources/IntegerUtilities/SaturatingArithmetic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2023 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/IntegerUtilities/ShiftWithRounding.swift
+++ b/Sources/IntegerUtilities/ShiftWithRounding.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/Numerics/CMakeLists.txt
+++ b/Sources/Numerics/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/Numerics/Numerics.swift
+++ b/Sources/Numerics/Numerics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/AlgebraicField.swift
+++ b/Sources/RealModule/AlgebraicField.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/ApproximateEquality.swift
+++ b/Sources/RealModule/ApproximateEquality.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/AugmentedArithmetic.swift
+++ b/Sources/RealModule/AugmentedArithmetic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/CMakeLists.txt
+++ b/Sources/RealModule/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/Double+Real.swift
+++ b/Sources/RealModule/Double+Real.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/ElementaryFunctions.swift
+++ b/Sources/RealModule/ElementaryFunctions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/Float+Real.swift
+++ b/Sources/RealModule/Float+Real.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/Float80+Real.swift
+++ b/Sources/RealModule/Float80+Real.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/Real.swift
+++ b/Sources/RealModule/Real.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/RealFunctions.swift
+++ b/Sources/RealModule/RealFunctions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/RealModule/RelaxedArithmetic.swift
+++ b/Sources/RealModule/RelaxedArithmetic.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_NumericsShims/CMakeLists.txt
+++ b/Sources/_NumericsShims/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/_NumericsShims/_NumericsShims.c
+++ b/Sources/_NumericsShims/_NumericsShims.c
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_NumericsShims/include/_NumericsShims.h
+++ b/Sources/_NumericsShims/include/_NumericsShims.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/BlackHole.swift
+++ b/Sources/_TestSupport/BlackHole.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/CMakeLists.txt
+++ b/Sources/_TestSupport/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/DoubleWidth.swift
+++ b/Sources/_TestSupport/DoubleWidth.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2017 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/DoubleWidth.swift
+++ b/Sources/_TestSupport/DoubleWidth.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/Error.swift
+++ b/Sources/_TestSupport/Error.swift
@@ -1,12 +1,11 @@
 //===--- Error.swift ------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Sources/_TestSupport/Interval.swift
+++ b/Sources/_TestSupport/Interval.swift
@@ -1,12 +1,11 @@
 //===--- Interval.swift ---------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Sources/_TestSupport/RealTestSupport.swift
+++ b/Sources/_TestSupport/RealTestSupport.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Tests/ComplexTests/ApproximateEqualityTests.swift
+++ b/Tests/ComplexTests/ApproximateEqualityTests.swift
@@ -1,12 +1,11 @@
 //===--- ApproximateEqualityTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/ComplexTests/CMakeLists.txt
+++ b/Tests/ComplexTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Tests/ComplexTests/ElementaryFunctionTests.swift
+++ b/Tests/ComplexTests/ElementaryFunctionTests.swift
@@ -1,12 +1,11 @@
 //===--- ElementaryFunctionTests.swift ------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/ComplexTests/PropertyTests.swift
+++ b/Tests/ComplexTests/PropertyTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 - 2020 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/Executable/ComplexLog/main.swift
+++ b/Tests/Executable/ComplexLog/main.swift
@@ -1,12 +1,11 @@
 //===--- main.swift -------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/Executable/ComplexLog1p/main.swift
+++ b/Tests/Executable/ComplexLog1p/main.swift
@@ -1,12 +1,11 @@
 //===--- main.swift -------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/IntegerUtilitiesTests/CMakeLists.txt
+++ b/Tests/IntegerUtilitiesTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/DivideTests.swift
+++ b/Tests/IntegerUtilitiesTests/DivideTests.swift
@@ -1,12 +1,11 @@
 //===--- DivideTests.swift ------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
+++ b/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2017 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/GCDTests.swift
+++ b/Tests/IntegerUtilitiesTests/GCDTests.swift
@@ -1,12 +1,11 @@
 //===--- GCDTests.swift ---------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/IntegerUtilitiesTests/RotateTests.swift
+++ b/Tests/IntegerUtilitiesTests/RotateTests.swift
@@ -1,12 +1,11 @@
 //===--- RotateTests.swift ------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/IntegerUtilitiesTests/SaturatingArithmeticTests.swift
+++ b/Tests/IntegerUtilitiesTests/SaturatingArithmeticTests.swift
@@ -1,12 +1,11 @@
 //===--- SaturatingArithmeticTests.swift ----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/IntegerUtilitiesTests/ShiftTests.swift
+++ b/Tests/IntegerUtilitiesTests/ShiftTests.swift
@@ -1,12 +1,11 @@
 //===--- ShiftTests.swift -------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -1,12 +1,11 @@
 //===--- ApproximateEqualityTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/RealTests/AugmentedArithmeticTests.swift
+++ b/Tests/RealTests/AugmentedArithmeticTests.swift
@@ -1,12 +1,11 @@
 //===--- AugmentedArithmeticTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 

--- a/Tests/RealTests/CMakeLists.txt
+++ b/Tests/RealTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/ElementaryFunctionChecks.swift
+++ b/Tests/RealTests/ElementaryFunctionChecks.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/RelaxedArithmeticTests.swift
+++ b/Tests/RealTests/RelaxedArithmeticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/WindowsMain.swift
+++ b/Tests/WindowsMain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,7 +1,7 @@
 #[[
 This source file is part of the Swift Numerics open source project
 
-Copyright (c) 2019 Apple Inc. and the Swift Numerics project authors
+Copyright (c) 2019 - 2024 Apple Inc. and the Swift project authors
 Licensed under Apache License v2.0 with Runtime Library Exception
 
 See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
There are a few slightly different versions of license headers distributed along the files of the projects, so I tried to unify them using the existing headers and the template from `swift-collection` (https://github.com/apple/swift-collections/commit/540348f1475110b307e6c59b394c70d1468da229) - and update the year of all copyright notices in the process.