### PR TITLE
Make `Complex.magnitude` use the `Magnitude` type of the underlying `RealType`

### DIFF
--- a/Sources/ComplexModule/Complex+Numeric.swift
+++ b/Sources/ComplexModule/Complex+Numeric.swift
@@ -49,7 +49,7 @@ extension Complex: Numeric {
   ///
   /// See also `.length` and `.lengthSquared`.
   @_transparent
-  public var magnitude: RealType {
+  public var magnitude: RealType.Magnitude {
     guard isFinite else { return .infinity }
     return max(abs(x), abs(y))
   }


### PR DESCRIPTION
Currently, the type of `Complex.magnitude` is equal to the underlying `Real` type of the complex number. This is fine for Float[16|32|64] et al, but I believe incorrect, since `Real` does not necessary require `Magnitude` to always be of the same type.