### PR TITLE
Rework complex division

### DIFF
--- a/Sources/ComplexModule/Complex+AlgebraicField.swift
+++ b/Sources/ComplexModule/Complex+AlgebraicField.swift
@@ -42,6 +42,8 @@ extension Complex: AlgebraicField {
     return z * w.conjugate.divided(by: lenSq)
   }
   
+  @_alwaysEmitIntoClient // specialization
+  @inline(never)
   public static func rescaledDivide(_ z: Complex, _ w: Complex) -> Complex {
     if w.isZero { return .infinity }
     if !w.isFinite { return .zero }

--- a/Sources/ComplexModule/Complex+AlgebraicField.swift
+++ b/Sources/ComplexModule/Complex+AlgebraicField.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2019-2024 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -96,7 +96,7 @@ extension Complex: AlgebraicField {
     //
     //  Note that our final assembly of the result is different from Priest;
     //  he applies s to w twice, instead of once to w and once to z, and
-    //  does the product as (zw̅ʺ)*1/|wʹ|², while we do zʹ(w̅ʹ/|wʹ|²). We
+    //  does the product as (zw̅ʺ)*(1/|wʹ|²), while we do zʹ(w̅ʹ/|wʹ|²). We
     //  prefer our version for three reasons:
     //
     //  1. it extracts a little more ILP

--- a/Sources/ComplexModule/Complex+AlgebraicField.swift
+++ b/Sources/ComplexModule/Complex+AlgebraicField.swift
@@ -105,7 +105,7 @@ extension Complex: AlgebraicField {
     //     when tz and tw are computed exactly.
     //  3. it unlocks a future optimization where we hoist s and
     //     (w̅ʹ/|wʹ|²) and make divisions all fast-path without perturbing
-    //     rouding.
+    //     rounding.
     let s = RealType(
       sign: .plus,
       exponent: -3*w.magnitude.exponent/4,

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -30,6 +30,9 @@ func checkMultiply<T>(
 ) -> Bool {
   let observed = a*b
   let rel = relativeError(observed, expected)
+  // Even if the expected result is finite, we allow overflow if
+  // the two-norm of the expected result overflows.
+  if !expected.length.isFinite && !observed.isFinite { return false }
   guard rel <= allowed else {
     print("Over-large error in \(a)*\(b)")
     print("Expected: \(expected)\nObserved: \(observed)")
@@ -44,6 +47,9 @@ func checkDivide<T>(
 ) -> Bool {
   let observed = a/b
   let rel = relativeError(observed, expected)
+  // Even if the expected result is finite, we allow overflow if
+  // the two-norm of the expected result overflows.
+  if !expected.length.isFinite && !observed.isFinite { return false }
   guard rel <= allowed else {
     print("Over-large error in \(a)/\(b)")
     print("Expected: \(expected)\nObserved: \(observed)")
@@ -149,7 +155,7 @@ final class ArithmeticTests: XCTestCase {
   
   func testPolar() {
 #if (arch(arm64))
-    // testPolar(Float16.self)
+    testPolar(Float16.self)
 #endif
     testPolar(Float.self)
     testPolar(Double.self)
@@ -233,13 +239,5 @@ final class ArithmeticTests: XCTestCase {
     }
   }
    */
-  
-  @available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
-  func testSpecificFloat16Value() {
-    let a = Complex<Float16>(4.66, 3e-07)
-    let b = Complex<Float16>(-4.32e-05, 4.977e-05)
-    let q = a / b
-    XCTAssertEqual(q, Complex<Float16>(-46368.0, -53376.0))
-  }
 #endif
 }

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -168,8 +168,10 @@ final class ArithmeticTests: XCTestCase {
         }
   
   func testPolar() {
-#if (arch(arm64))
-    testPolar(Float16.self)
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+    if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+      testPolar(Float16.self)
+    }
 #endif
     testPolar(Float.self)
     testPolar(Double.self)

--- a/Tests/ComplexTests/ArithmeticTests.swift
+++ b/Tests/ComplexTests/ArithmeticTests.swift
@@ -41,10 +41,11 @@ func checkMultiply<T>(
   _ a: Complex<T>, _ b: Complex<T>, expected: Complex<T>, ulps allowed: T
 ) -> Bool {
   let observed = a*b
-  let rel = relativeError(observed, expected)
+  if observed == expected { return false }
   // Even if the expected result is finite, we allow overflow if
   // the two-norm of the expected result overflows.
   if !observed.isFinite && !expected.length.isFinite { return false }
+  let rel = relativeError(observed, expected)
   guard rel <= allowed else {
     print("Over-large error in \(a)*\(b)")
     print("Expected: \(expected)\nObserved: \(observed)")
@@ -58,10 +59,11 @@ func checkDivide<T>(
   _ a: Complex<T>, _ b: Complex<T>, expected: Complex<T>, ulps allowed: T
 ) -> Bool {
   let observed = a/b
-  let rel = relativeError(observed, expected)
+  if observed == expected { return false }
   // Even if the expected result is finite, we allow overflow if
   // the two-norm of the expected result overflows.
   if !observed.isFinite && !expected.length.isFinite { return false }
+  let rel = relativeError(observed, expected)
   guard rel <= allowed else {
     print("Over-large error in \(a)/\(b)")
     print("Expected: \(expected)\nObserved: \(observed)")


### PR DESCRIPTION
Replaces the rescaling algorithm for Complex division to one inspired by Doug Priest's "Efficient Scaling for Complex Division," with some further tweaks to:
1. allow it to work for arbitrary FloatingPoint types, including Float16
2. get exactly the same rounding behavior as the un-rescaled path, so that z/w = tz/tw when tz and tw are computed exactly.
3. allow future optimizations to hoist a rescaled reciprocal for more speedups.

Unlike Priest, we _do not_ try to avoid spurious overflow in the final computation when the result is very near the overflow boundary but cancellation brings us just inside it. We do not believe that this is a good tradeoff, as complex multiplication overflows in exactly the same way. We will investigate providing opt-in API to avoid this overflow case in a future PR.