### PR TITLE
Integer midpoint

### DIFF
--- a/Sources/IntegerUtilities/Midpoint.swift
+++ b/Sources/IntegerUtilities/Midpoint.swift
@@ -1,0 +1,108 @@
+//===--- Midpoint.swift ---------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift Numerics open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift Numerics project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// The average of `a` and `b`, rounded to an integer according to `rule`.
+///
+/// Unlike commonly seen expressions such as `(a+b)/2` or `(a+b) >> 1` or
+/// `a + (b-a)/2` (all of which may overflow for fixed-width integers),
+/// this function never overflows, and the result is guaranteed to be
+/// representable in the result type.
+///
+/// The default rounding rule is `.down`, which matches the behavior of
+/// `(a + b) >> 1` when that expression does not overflow. Rounding
+/// `.towardZero` matches the behavior of `(a + b)/2` when that expression
+/// does not overflow. All other rounding modes are supported.
+///
+/// Rounding `.down` is generally most efficient; if you do not have a
+/// reason to chose a specific other rounding rule, you should use the
+/// default. 
+@inlinable
+public func midpoint<T: BinaryInteger>(
+  _ a: T,
+  _ b: T,
+  rounding rule: RoundingRule = .down
+) -> T {
+  // Isolate bits in a + b with weight 2, and those with weight 1.
+  let twos = a & b
+  let ones = a ^ b
+  let floor = twos + ones >> 1
+  let frac = ones & 1
+  switch rule {
+  case .down:
+    return floor
+  case .up:
+    return floor + frac
+  case .towardZero:
+    return floor + (floor < 0 ? frac : 0)
+  case .toNearestOrAwayFromZero:
+    fallthrough
+  case .awayFromZero:
+    return floor + (floor >= 0 ? frac : 0)
+  case .toNearestOrEven:
+    return floor + (floor & frac)
+  case .toOdd:
+    return floor + (~floor & frac)
+  case .stochastically:
+    return floor + (Bool.random() ? frac : 0)
+  case .requireExact:
+    precondition(frac == 0)
+    return floor
+  }
+}
+
+/// The average of `a` and `b`, rounded to an integer according to `rule`.
+///
+/// Unlike commonly seen expressions such as `(a+b)/2` or `(a+b) >> 1` or
+/// `a + (b-a)/2` (all of which may overflow), this function never overflows,
+/// and the result is guaranteed to be representable in the result type.
+///
+/// The default rounding rule is `.down`, which matches the behavior of
+/// `(a + b) >> 1` when that expression does not overflow. Rounding
+/// `.towardZero` matches the behavior of `(a + b)/2` when that expression
+/// does not overflow. All other rounding modes are supported.
+///
+/// Rounding `.down` is generally most efficient; if you do not have a
+/// reason to chose a specific other rounding rule, you should use the
+/// default.
+@inlinable
+public func midpoint<T: FixedWidthInteger>(
+  _ a: T,
+  _ b: T,
+  rounding rule: RoundingRule = .down
+) -> T {
+  // Isolate bits in a + b with weight 2, and those with weight 1
+  let twos = a & b
+  let ones = a ^ b
+  let floor = twos &+ ones >> 1
+  let frac = ones & 1
+  switch rule {
+  case .down:
+    return floor
+  case .up:
+    return floor &+ frac
+  case .towardZero:
+    return floor &+ (floor < 0 ? frac : 0)
+  case .toNearestOrAwayFromZero:
+    fallthrough
+  case .awayFromZero:
+    return floor &+ (floor >= 0 ? frac : 0)
+  case .toNearestOrEven:
+    return floor &+ (floor & frac)
+  case .toOdd:
+    return floor &+ (~floor & frac)
+  case .stochastically:
+    return floor &+ (Bool.random() ? frac : 0)
+  case .requireExact:
+    precondition(frac == 0)
+    return floor
+  }
+}
+

--- a/Tests/IntegerUtilitiesTests/MidpointTests.swift
+++ b/Tests/IntegerUtilitiesTests/MidpointTests.swift
@@ -1,0 +1,39 @@
+//===--- MidpointTests.swift ----------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import IntegerUtilities
+import XCTest
+
+final class IntegerUtilitiesMidpointTests: XCTestCase {
+  func testMidpoint() {
+    for rule in [
+      RoundingRule.down,
+      .up,
+      .towardZero,
+      .awayFromZero,
+      .toNearestOrEven,
+      .toNearestOrAwayFromZero,
+      .toOdd
+    ] {
+      for a in -128 ... 127 {
+        for b in -128 ... 127 {
+          let ref = (a + b).shifted(rightBy: 1, rounding: rule)
+          let tst = midpoint(Int8(a), Int8(b), rounding: rule)
+          if ref != tst {
+            print(rule, a, b, ref, tst, separator: "\t")
+            return
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overflow-safe integer midpoint with rounding control

A common source of integer and pointer overflows and out-of-bounds accesses across programming languages is midpoint computations for the purposes of collection algorithms. Swift's checked arithmetic and accesses prevent errors, but may still result in spurious crashes when this operation is implemented incorrectly.

Further, rounding-control for integer arithmetic is subtle and easy to get wrong, and further complicates overflow prevention (midpoint _should_ never overflow, no matter how it is rounded, but achieving this can be tricky). For some algorithms it is desirable to round up or down or to even; we simply implement all of the options.

Draft because I am not sold on the free-function spelling `midpoint(a, b)`. It is desirable by symmetry with `min(a, b)` and `max(a, b)`, and because it correctly captures that this is a commutative operation; neither operand is privileged. But Swift generally eschews free functions. This could equally be a static member (`Int.midpoint(a, b)`), or possibly use some other spelling.