### PR TITLE
Some file headers have the Swift.org text instead of Swift Numerics

### DIFF
--- a/Sources/ComplexModule/Complex+ElementaryFunctions.swift
+++ b/Sources/ComplexModule/Complex+ElementaryFunctions.swift
@@ -1,8 +1,8 @@
 //===--- Complex+ElementaryFunctions.swift --------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2019-2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2019-2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/Error.swift
+++ b/Sources/_TestSupport/Error.swift
@@ -1,8 +1,8 @@
 //===--- Error.swift ------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/_TestSupport/Interval.swift
+++ b/Sources/_TestSupport/Interval.swift
@@ -1,8 +1,8 @@
 //===--- Interval.swift ---------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/ComplexTests/ApproximateEqualityTests.swift
+++ b/Tests/ComplexTests/ApproximateEqualityTests.swift
@@ -1,8 +1,8 @@
 //===--- ApproximateEqualityTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/ComplexTests/ElementaryFunctionTests.swift
+++ b/Tests/ComplexTests/ElementaryFunctionTests.swift
@@ -1,8 +1,8 @@
 //===--- ElementaryFunctionTests.swift ------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/Executable/ComplexLog/main.swift
+++ b/Tests/Executable/ComplexLog/main.swift
@@ -1,8 +1,8 @@
 //===--- main.swift -------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/Executable/ComplexLog1p/main.swift
+++ b/Tests/Executable/ComplexLog1p/main.swift
@@ -1,8 +1,8 @@
 //===--- main.swift -------------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/DivideTests.swift
+++ b/Tests/IntegerUtilitiesTests/DivideTests.swift
@@ -1,8 +1,8 @@
 //===--- DivideTests.swift ------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/GCDTests.swift
+++ b/Tests/IntegerUtilitiesTests/GCDTests.swift
@@ -1,8 +1,8 @@
 //===--- GCDTests.swift ---------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/RotateTests.swift
+++ b/Tests/IntegerUtilitiesTests/RotateTests.swift
@@ -1,8 +1,8 @@
 //===--- RotateTests.swift ------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/SaturatingArithmeticTests.swift
+++ b/Tests/IntegerUtilitiesTests/SaturatingArithmeticTests.swift
@@ -1,8 +1,8 @@
 //===--- SaturatingArithmeticTests.swift ----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/ShiftTests.swift
+++ b/Tests/IntegerUtilitiesTests/ShiftTests.swift
@@ -1,8 +1,8 @@
 //===--- ShiftTests.swift -------------------------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/ApproximateEqualityTests.swift
+++ b/Tests/RealTests/ApproximateEqualityTests.swift
@@ -1,8 +1,8 @@
 //===--- ApproximateEqualityTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/RealTests/AugmentedArithmeticTests.swift
+++ b/Tests/RealTests/AugmentedArithmeticTests.swift
@@ -1,8 +1,8 @@
 //===--- AugmentedArithmeticTests.swift -----------------------*- swift -*-===//
 //
-// This source file is part of the Swift.org open source project
+// This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
These are a copy-pasto from introduced when I originally imported approximate equality (which was originally proposed for the standard library).