### PR TITLE
Improvements and bugfixes for DoubleWidth

### DIFF
--- a/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
+++ b/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
@@ -522,4 +522,8 @@ final class DoubleWidthTests: XCTestCase {
     checkUnsignedIntegerConformance(0 as _UInt128)
     checkUnsignedIntegerConformance(0 as _UInt1024)
   }
+  
+  func testMultiplyOverflow() {
+    XCTAssertFalse(_Int128(-1).multipliedReportingOverflow(by: 0).overflow)
+  }
 }


### PR DESCRIPTION
These are used only in TestSupport, but it's still nice to get them right. Signed types had a long-standing bug in how overflow was computed for multiplication, and masking shifts would do the wrong thing when the bitwdith was not a power of two and the shift count was negative. I also added implementations of `&*`, `&+`, and `&-`.