### PR TITLE
Add new rounding modes: toNearestOr[Down,Up,Zero,Away]

### DIFF
--- a/Sources/IntegerUtilities/DivideWithRounding.swift
+++ b/Sources/IntegerUtilities/DivideWithRounding.swift
@@ -117,24 +117,20 @@ extension BinaryInteger {
       if q._lowWord & 1 == 1 { return q }
       
     case .stochastically:
-      var qhi: UInt64
+      let bmag = other.magnitude
+      let rmag = r.magnitude
+      var bhi: UInt64
       var rhi: UInt64
       if other.magnitude <= UInt64.max {
-        qhi = UInt64(other.magnitude)
-        rhi = UInt64(r.magnitude)
+        bhi = UInt64(bmag)
+        rhi = UInt64(rmag)
       } else {
-        // TODO: this is untested currently.
-        let qmag = other.magnitude
-        let shift = qmag._msb - 1
-        qhi = UInt64(truncatingIfNeeded: qmag >> shift)
-        rhi = UInt64(truncatingIfNeeded: r.magnitude >> shift)
+        let shift = bmag._msb - 63
+        bhi = UInt64(truncatingIfNeeded: bmag >> shift)
+        rhi = UInt64(truncatingIfNeeded: rmag >> shift)
       }
-      let (sum, car) = rhi.addingReportingOverflow(.random(in: 0 ..< qhi))
-      if car || sum >= qhi {
-        if (other > 0) != (r > 0) { return q-1 }
-        return q+1
-      }
-      return q
+      let (sum, car) = rhi.addingReportingOverflow(.random(in: 0 ..< bhi))
+      if sum < bhi && !car { return q }
       
     case .requireExact:
       preconditionFailure("Division was not exact.")
@@ -304,24 +300,20 @@ extension SignedInteger {
       if q._lowWord & 1 == 1 { return (q, r) }
       
     case .stochastically:
-      var qhi: UInt64
+      let bmag = other.magnitude
+      let rmag = r.magnitude
+      var bhi: UInt64
       var rhi: UInt64
       if other.magnitude <= UInt64.max {
-        qhi = UInt64(other.magnitude)
-        rhi = UInt64(r.magnitude)
+        bhi = UInt64(bmag)
+        rhi = UInt64(rmag)
       } else {
-        // TODO: this is untested currently.
-        let qmag = other.magnitude
-        let shift = qmag._msb - 1
-        qhi = UInt64(truncatingIfNeeded: qmag >> shift)
-        rhi = UInt64(truncatingIfNeeded: r.magnitude >> shift)
+        let shift = bmag._msb - 63
+        bhi = UInt64(truncatingIfNeeded: bmag >> shift)
+        rhi = UInt64(truncatingIfNeeded: rmag >> shift)
       }
-      let (sum, car) = rhi.addingReportingOverflow(.random(in: 0 ..< qhi))
-      if car || sum >= qhi {
-        if (other > 0) != (r > 0) { return (q-1, r+other) }
-        return (q+1, r-other)
-      }
-      return (q, r)
+      let (sum, car) = rhi.addingReportingOverflow(.random(in: 0 ..< bhi))
+      if sum < bhi && !car { return (q, r) }
       
     case .requireExact:
       preconditionFailure("Division was not exact.")

--- a/Sources/IntegerUtilities/SaturatingArithmetic.swift
+++ b/Sources/IntegerUtilities/SaturatingArithmetic.swift
@@ -95,7 +95,7 @@ extension FixedWidthInteger {
     return Self.max &- high.signbit
   }
     
-  /// Bitwise left with rounding and saturation.
+  /// Bitwise left shift with rounding and saturation.
   ///
   /// `self` multiplied by the rational number 2^(`count`), saturated to the
   /// range `Self.min ... Self.max`, and rounded according to `rule`.
@@ -154,8 +154,8 @@ extension FixedWidthInteger {
   /// shifts with examples.
   ///
   /// - Parameters:
-  ///   - leftBy count: the number of bits to shift by. If positive, this is a left-shift,
-  ///   and if negative a right shift.
+  ///   - leftBy count: the number of bits to shift by. If positive, this is a
+  ///     left-shift, and if negative a right shift.
   ///   - rounding rule: the direction in which to round if `count` is negative.
   @_transparent
   public func shiftedWithSaturation<Count: BinaryInteger>(

--- a/Tests/IntegerUtilitiesTests/DivideTests.swift
+++ b/Tests/IntegerUtilitiesTests/DivideTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import IntegerUtilities
+import _TestSupport
 import XCTest
 
 final class IntegerUtilitiesDivideTests: XCTestCase {
@@ -435,6 +436,27 @@ final class IntegerUtilitiesDivideTests: XCTestCase {
     testDivideStochastic(values)
     testDivideExact(values)
   }
+
+  func testDivideInt128() {
+    var values = [DoubleWidth<Int64>](repeating: 0, count: 64)
+    for i in 0 ..< values.count {
+      while values[i] == 0 {
+        values[i] = .random(in: .min ... .max)
+      }
+    }
+    testDivideDown(values)
+    testDivideUp(values)
+    testDivideTowardZero(values)
+    testDivideAwayFromZero(values)
+    testDivideToNearestOrDown(values)
+    testDivideToNearestOrUp(values)
+    testDivideToNearestOrZero(values)
+    testDivideToNearestOrAway(values)
+    testDivideToNearestOrEven(values)
+    testDivideToOdd(values)
+    testDivideStochastic(values)
+    testDivideExact(values)
+  }
   
   func divideUInt8(_ a: UInt8, _ b: UInt8, rounding rule: RoundingRule) {
     let expected = UInt8(Int16(a).divided(by: Int16(b), rounding: rule).quotient)
@@ -477,11 +499,12 @@ final class IntegerUtilitiesDivideTests: XCTestCase {
   // check that it is acceptably close to the exact expected value; simple
   // use of any deterministic rounding rule will not achieve this.
   func testStochasticDivide<T: FixedWidthInteger>(_ a: T, _ b: T) -> Bool {
+    let trunc = a/b
     let sum = (0..<1024).reduce(into: 0.0) { sum, _ in
-      let rounded = a.divided(by: b, rounding: .stochastically)
-      sum += Double(rounded)
+      let rounding = a.divided(by: b, rounding: .stochastically) - trunc
+      sum += Double(rounding)
     }
-    let expected = 1024 * Double(a) / Double(b)
+    let expected = 1024*Double(a%b)/Double(b)
     let difference = abs(sum - expected)
     // Waving my hands slightly instead of giving a precise explanation
     // here, the expectation is that difference should be about

--- a/Tests/IntegerUtilitiesTests/DivideTests.swift
+++ b/Tests/IntegerUtilitiesTests/DivideTests.swift
@@ -467,44 +467,6 @@ final class IntegerUtilitiesDivideTests: XCTestCase {
     }
   }
   
-  @available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
-  func divideUInt64(_ a: UInt64, _ b: UInt64, rounding rule: RoundingRule) {
-    let expected = UInt64(Int128(a).divided(by: Int128(b), rounding: rule).quotient)
-    let observed = a.divided(by: b, rounding: rule)
-    guard expected == observed else {
-      XCTFail("""
-      \(a).divided(by: \(b), rounding: \(rule)) did not match expected result:
-      Computed with Int128: \(expected)
-      Computed with UInt64: \(observed)
-      """)
-      return
-    }
-  }
-  
-  @available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
-  func testDivideUInt64() {
-    var values = [UInt64](repeating: 0, count: 64)
-    for i in 0 ..< values.count {
-      while values[i] == 0 {
-        values[i] = .random(in: .min ... .max)
-      }
-    }
-    for a in values {
-      for b in values where b != 0 {
-        divideUInt64(a, b, rounding: .down)
-        divideUInt64(a, b, rounding: .up)
-        divideUInt64(a, b, rounding: .towardZero)
-        divideUInt64(a, b, rounding: .awayFromZero)
-        divideUInt64(a, b, rounding: .toNearestOrDown)
-        divideUInt64(a, b, rounding: .toNearestOrUp)
-        divideUInt64(a, b, rounding: .toNearestOrZero)
-        divideUInt64(a, b, rounding: .toNearestOrAway)
-        divideUInt64(a, b, rounding: .toNearestOrEven)
-        divideUInt64(a, b, rounding: .toOdd)
-      }
-    }
-  }
-  
   // stochastically rounding doesn't have a deterministic "expected" answer,
   // but we know that the result must be either the floor or the ceiling.
   // The above tests ensure that, but that's not a very strong guarantee;

--- a/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
+++ b/Tests/IntegerUtilitiesTests/DoubleWidthTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2017-2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2017-2024 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/IntegerUtilitiesTests/ShiftTests.swift
+++ b/Tests/IntegerUtilitiesTests/ShiftTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Numerics open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift Numerics project authors
+// Copyright (c) 2021-2024 Apple Inc. and the Swift Numerics project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -24,20 +24,44 @@ final class IntegerUtilitiesShiftTests: XCTestCase {
     let exact = count <= 0 || lost == 0
     let ceiling = exact ? floor : floor &+ 1
     let expected: T
-    switch rule {
-    case .down:
-      expected = floor
-    case .up:
-      expected = ceiling
-    case .towardZero:
-      expected = value < 0 ? ceiling : floor
-    case .awayFromZero:
-      expected = value > 0 ? ceiling : floor
-    case .toOdd:
-      expected = floor | (exact ? 0 : 1)
-    case .toNearestOrAwayFromZero:
-      if exact { expected = floor }
-      else {
+    if exact { expected = floor }
+    else {
+      switch rule {
+      case .down:
+        expected = floor
+      case .up:
+        expected = ceiling
+      case .towardZero:
+        expected = value < 0 ? ceiling : floor
+      case .awayFromZero:
+        expected = value > 0 ? ceiling : floor
+      case .toOdd:
+        expected = floor | (exact ? 0 : 1)
+      case .toNearestOrDown:
+        let step = value.shifted(rightBy: count - 2, rounding: .toOdd)
+        switch step & 0b11 {
+        case 0b01: expected = floor
+        case 0b10: expected = floor
+        case 0b11: expected = ceiling
+        default: preconditionFailure()
+        }
+      case .toNearestOrUp:
+        let step = value.shifted(rightBy: count - 2, rounding: .toOdd)
+        switch step & 0b11 {
+        case 0b01: expected = floor
+        case 0b10: expected = ceiling
+        case 0b11: expected = ceiling
+        default: preconditionFailure()
+        }
+      case .toNearestOrZero:
+        let step = value.shifted(rightBy: count - 2, rounding: .toOdd)
+        switch step & 0b11 {
+        case 0b01: expected = floor
+        case 0b10: expected = value > 0 ? floor : ceiling
+        case 0b11: expected = ceiling
+        default: preconditionFailure()
+        }
+      case .toNearestOrAway:
         let step = value.shifted(rightBy: count - 2, rounding: .toOdd)
         switch step & 0b11 {
         case 0b01: expected = floor
@@ -45,10 +69,7 @@ final class IntegerUtilitiesShiftTests: XCTestCase {
         case 0b11: expected = ceiling
         default: preconditionFailure()
         }
-      }
-    case .toNearestOrEven:
-      if exact { expected = floor }
-      else {
+      case .toNearestOrEven:
         let step = value.shifted(rightBy: count - 2, rounding: .toOdd)
         switch step & 0b11 {
         case 0b01: expected = floor
@@ -56,142 +77,181 @@ final class IntegerUtilitiesShiftTests: XCTestCase {
         case 0b11: expected = ceiling
         default: preconditionFailure()
         }
-      }
-    case .stochastically:
-      // Just test that it's floor if exact, otherwise either floor
-      // or ceiling.
-      if exact { expected = floor }
-      else {
+      case .stochastically:
+        // Just test that it's floor if exact, otherwise either floor
+        // or ceiling.
         let observed = value.shifted(rightBy: count, rounding: rule)
         if observed != floor && observed != ceiling {
           print("Error found in \(T.self).shifted(rightBy: \(count), rounding: \(rule)).")
-          print("   Value: \(String(value, radix: 16))")
-          print("Expected: \(String(floor, radix: 16)) or \(String(ceiling, radix: 16))")
-          print("Observed: \(String(observed, radix: 16))")
+          print("   Value: \(String(value, radix: 2))")
+          print("Expected: \(String(floor, radix: 2)) or \(String(ceiling, radix: 2))")
+          print("Observed: \(String(observed, radix: 2))")
           XCTFail()
         }
         return
+      case .requireExact:
+        preconditionFailure()
       }
-    case .requireExact:
-      preconditionFailure()
-    }
-    let observed = value.shifted(rightBy: count, rounding: rule)
-    if observed != expected {
-      print("Error found in \(T.self).shifted(rightBy: \(count), rounding: \(rule)).")
-      print("   Value: \(String(value, radix: 16))")
-      print("Expected: \(String(expected, radix: 16))")
-      print("Observed: \(String(observed, radix: 16))")
-      XCTFail()
+      let observed = value.shifted(rightBy: count, rounding: rule)
+      if observed != expected {
+        print("Error found in \(T.self).shifted(rightBy: \(count), rounding: \(rule)).")
+        print("   Value: \(String(value, radix: 2))")
+        print("Expected: \(String(expected, radix: 2))")
+        print("Observed: \(String(observed, radix: 2))")
+        XCTFail()
+      }
     }
   }
-  
-  func testRoundingShift<T: FixedWidthInteger>(
-    _ type: T.Type, rounding rule: RoundingRule
-  ) {
-    for count in -2*T.bitWidth ... 2*T.bitWidth {
-      // zero shifted by anything is always zero
-      XCTAssertEqual(0, (0 as T).shifted(rightBy: count, rounding: rule))
-      for _ in 0 ..< 100 {
+    
+    func testRoundingShift<T: FixedWidthInteger>(
+      _ type: T.Type, rounding rule: RoundingRule
+    ) {
+      for count in -2*T.bitWidth ... 2*T.bitWidth {
+        // zero shifted by anything is always zero
+        XCTAssertEqual(0, (0 as T).shifted(rightBy: count, rounding: rule))
+        for _ in 0 ..< 100 {
+          testRoundingShift(T.random(in: .min ... .max), count, rounding: rule)
+        }
+      }
+      
+      for count in Int8.min ... .max {
         testRoundingShift(T.random(in: .min ... .max), count, rounding: rule)
       }
     }
     
-    for count in Int8.min ... .max {
-      testRoundingShift(T.random(in: .min ... .max), count, rounding: rule)
-    }
-  }
-  
-  func testRoundingShifts() {
-    testRoundingShift(Int8.self, rounding: .down)
-    testRoundingShift(Int8.self, rounding: .up)
-    testRoundingShift(Int8.self, rounding: .towardZero)
-    testRoundingShift(Int8.self, rounding: .awayFromZero)
-    testRoundingShift(Int8.self, rounding: .toOdd)
-    testRoundingShift(Int8.self, rounding: .toNearestOrAwayFromZero)
-    testRoundingShift(Int8.self, rounding: .toNearestOrEven)
-    testRoundingShift(Int8.self, rounding: .stochastically)
-    
-    testRoundingShift(UInt8.self, rounding: .down)
-    testRoundingShift(UInt8.self, rounding: .up)
-    testRoundingShift(UInt8.self, rounding: .towardZero)
-    testRoundingShift(UInt8.self, rounding: .awayFromZero)
-    testRoundingShift(UInt8.self, rounding: .toOdd)
-    testRoundingShift(UInt8.self, rounding: .toNearestOrAwayFromZero)
-    testRoundingShift(UInt8.self, rounding: .toNearestOrEven)
-    testRoundingShift(UInt8.self, rounding: .stochastically)
-    
-    testRoundingShift(Int.self, rounding: .down)
-    testRoundingShift(Int.self, rounding: .up)
-    testRoundingShift(Int.self, rounding: .towardZero)
-    testRoundingShift(Int.self, rounding: .awayFromZero)
-    testRoundingShift(Int.self, rounding: .toOdd)
-    testRoundingShift(Int.self, rounding: .toNearestOrAwayFromZero)
-    testRoundingShift(Int.self, rounding: .toNearestOrEven)
-    testRoundingShift(Int.self, rounding: .stochastically)
-    
-    testRoundingShift(UInt.self, rounding: .down)
-    testRoundingShift(UInt.self, rounding: .up)
-    testRoundingShift(UInt.self, rounding: .towardZero)
-    testRoundingShift(UInt.self, rounding: .awayFromZero)
-    testRoundingShift(UInt.self, rounding: .toOdd)
-    testRoundingShift(UInt.self, rounding: .toNearestOrAwayFromZero)
-    testRoundingShift(UInt.self, rounding: .toNearestOrEven)
-    testRoundingShift(UInt.self, rounding: .stochastically)
-  }
-  
-  // Stochastic rounding doesn't have a deterministic "expected" answer,
-  // but we know that the result must be either the floor or the ceiling.
-  // The above tests ensure that, but that's not a very strong guarantee;
-  // an implementation could just implement it as self >> count and pass
-  // that test.
-  //
-  // Here we round the _same_ value many times, compute the average, and
-  // check that it is acceptably close to the exact expected value; simple
-  // use of any deterministic rounding rule will not achieve this.
-  func testStochasticAverage<T: FixedWidthInteger>(_ value: T) {
-    var fails = 0
-    for count in 1 ... T.bitWidth {
-      let sum = (0..<256).reduce(into: DoubleWidth<T>.zero) { sum, _ in
-        let rounded = value.shifted(rightBy: count, rounding: .stochastically)
-        sum += DoubleWidth(rounded)
+    func testRoundingShifts() {
+      testRoundingShift(Int8.self, rounding: .down)
+      testRoundingShift(Int8.self, rounding: .up)
+      testRoundingShift(Int8.self, rounding: .towardZero)
+      testRoundingShift(Int8.self, rounding: .awayFromZero)
+      testRoundingShift(Int8.self, rounding: .toNearestOrUp)
+      testRoundingShift(Int8.self, rounding: .toNearestOrDown)
+      testRoundingShift(Int8.self, rounding: .toNearestOrZero)
+      testRoundingShift(Int8.self, rounding: .toNearestOrAway)
+      testRoundingShift(Int8.self, rounding: .toNearestOrEven)
+      testRoundingShift(Int8.self, rounding: .toOdd)
+      testRoundingShift(Int8.self, rounding: .stochastically)
+      
+      testRoundingShift(UInt8.self, rounding: .down)
+      testRoundingShift(UInt8.self, rounding: .up)
+      testRoundingShift(UInt8.self, rounding: .towardZero)
+      testRoundingShift(UInt8.self, rounding: .awayFromZero)
+      testRoundingShift(UInt8.self, rounding: .toNearestOrUp)
+      testRoundingShift(UInt8.self, rounding: .toNearestOrDown)
+      testRoundingShift(UInt8.self, rounding: .toNearestOrZero)
+      testRoundingShift(UInt8.self, rounding: .toNearestOrAway)
+      testRoundingShift(UInt8.self, rounding: .toNearestOrEven)
+      testRoundingShift(UInt8.self, rounding: .toOdd)
+      testRoundingShift(UInt8.self, rounding: .stochastically)
+      
+      testRoundingShift(Int.self, rounding: .down)
+      testRoundingShift(Int.self, rounding: .up)
+      testRoundingShift(Int.self, rounding: .towardZero)
+      testRoundingShift(Int.self, rounding: .awayFromZero)
+      testRoundingShift(Int.self, rounding: .toNearestOrUp)
+      testRoundingShift(Int.self, rounding: .toNearestOrDown)
+      testRoundingShift(Int.self, rounding: .toNearestOrZero)
+      testRoundingShift(Int.self, rounding: .toNearestOrAway)
+      testRoundingShift(Int.self, rounding: .toNearestOrEven)
+      testRoundingShift(Int.self, rounding: .toOdd)
+      testRoundingShift(Int.self, rounding: .stochastically)
+      
+      testRoundingShift(UInt.self, rounding: .down)
+      testRoundingShift(UInt.self, rounding: .up)
+      testRoundingShift(UInt.self, rounding: .towardZero)
+      testRoundingShift(UInt.self, rounding: .awayFromZero)
+      testRoundingShift(UInt.self, rounding: .toNearestOrUp)
+      testRoundingShift(UInt.self, rounding: .toNearestOrDown)
+      testRoundingShift(UInt.self, rounding: .toNearestOrZero)
+      testRoundingShift(UInt.self, rounding: .toNearestOrAway)
+      testRoundingShift(UInt.self, rounding: .toNearestOrEven)
+      testRoundingShift(UInt.self, rounding: .toOdd)
+      testRoundingShift(UInt.self, rounding: .stochastically)
+      
+      if #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) {
+        testRoundingShift(Int128.self, rounding: .down)
+        testRoundingShift(Int128.self, rounding: .up)
+        testRoundingShift(Int128.self, rounding: .towardZero)
+        testRoundingShift(Int128.self, rounding: .awayFromZero)
+        testRoundingShift(Int128.self, rounding: .toNearestOrUp)
+        testRoundingShift(Int128.self, rounding: .toNearestOrDown)
+        testRoundingShift(Int128.self, rounding: .toNearestOrZero)
+        testRoundingShift(Int128.self, rounding: .toNearestOrAway)
+        testRoundingShift(Int128.self, rounding: .toNearestOrEven)
+        testRoundingShift(Int128.self, rounding: .toOdd)
+        testRoundingShift(Int128.self, rounding: .stochastically)
+        
+        testRoundingShift(UInt128.self, rounding: .down)
+        testRoundingShift(UInt128.self, rounding: .up)
+        testRoundingShift(UInt128.self, rounding: .towardZero)
+        testRoundingShift(UInt128.self, rounding: .awayFromZero)
+        testRoundingShift(UInt128.self, rounding: .toNearestOrUp)
+        testRoundingShift(UInt128.self, rounding: .toNearestOrDown)
+        testRoundingShift(UInt128.self, rounding: .toNearestOrZero)
+        testRoundingShift(UInt128.self, rounding: .toNearestOrAway)
+        testRoundingShift(UInt128.self, rounding: .toNearestOrEven)
+        testRoundingShift(UInt128.self, rounding: .toOdd)
+        testRoundingShift(UInt128.self, rounding: .stochastically)
       }
-      let expected = DoubleWidth<T>(value) << (8 - count)
-      let difference = sum >= expected ? sum - expected : expected - sum
-      // Waving my hands slightly instead of giving a precise explanation
-      // here, the expectation is that difference should be about
-      // 1/2 sqrt(256). If it's repeatedly bigger than that, we _may_
-      // have a problem, but it's OK for this to fail occasionally.
-      //
-      // TODO: precise justification of thresholds
-      if difference > 8 { fails += 1 }
-      // On the other hand, if we're more than a couple standard deviations
-      // off, we should flag that. This still isn't _necessarily_ a problem,
-      // but if you see a repeated failure for a given shift count, that's
-      // almost surely a real bug.
-      XCTAssertLessThanOrEqual(difference, 32,
-      "Accumulated error (\(difference)) was unexpectedly large in \(value).shifted(rightBy: \(count))"
+    }
+    
+    // Stochastic rounding doesn't have a deterministic "expected" answer,
+    // but we know that the result must be either the floor or the ceiling.
+    // The above tests ensure that, but that's not a very strong guarantee;
+    // an implementation could just implement it as self >> count and pass
+    // that test.
+    //
+    // Here we round the _same_ value many times, compute the average, and
+    // check that it is acceptably close to the exact expected value; simple
+    // use of any deterministic rounding rule will not achieve this.
+    func testStochasticAverage<T: FixedWidthInteger>(_ value: T) {
+      var fails = 0
+      for count in 1 ... T.bitWidth {
+        let sum = (0..<256).reduce(into: DoubleWidth<T>.zero) { sum, _ in
+          let rounded = value.shifted(rightBy: count, rounding: .stochastically)
+          sum += DoubleWidth(rounded)
+        }
+        let expected = DoubleWidth<T>(value) << (8 - count)
+        let difference = sum >= expected ? sum - expected : expected - sum
+        // Waving my hands slightly instead of giving a precise explanation
+        // here, the expectation is that difference should be about
+        // 1/2 sqrt(256). If it's repeatedly bigger than that, we _may_
+        // have a problem, but it's OK for this to fail occasionally.
+        //
+        // TODO: precise justification of thresholds
+        if difference > 8 { fails += 1 }
+        // On the other hand, if we're more than a couple standard deviations
+        // off, we should flag that. This still isn't _necessarily_ a problem,
+        // but if you see a repeated failure for a given shift count, that's
+        // almost surely a real bug.
+        XCTAssertLessThanOrEqual(difference, 32,
+                                 "Accumulated error (\(difference)) was unexpectedly large in \(value).shifted(rightBy: \(count))"
+        )
+      }
+      // Threshold chosen so that this is expected to _usually_ pass, but
+      // it will fail sporadically even with a correct implementation. This is
+      // not a great fit for CI workflows, sorry. Basically ignore one-off
+      // failures, but a repeated failure here is an indication that a bug
+      // exists.
+      XCTAssertLessThanOrEqual(fails, T.bitWidth/2,
+                               "Accumulated error was large more often than expected for \(value).shifted(rightBy:)"
       )
     }
-    // Threshold chosen so that this is expected to _usually_ pass, but
-    // it will fail sporadically even with a correct implementation. This is
-    // not a great fit for CI workflows, sorry. Basically ignore one-off
-    // failures, but a repeated failure here is an indication that a bug
-    // exists.
-    XCTAssertLessThanOrEqual(fails, T.bitWidth/2,
-    "Accumulated error was large more often than expected for \(value).shifted(rightBy:)"
-    )
+    
+    func testStochasticShifts() {
+      testStochasticAverage(Int8.random(in: .min ... .max))
+      testStochasticAverage(Int16.random(in: .min ... .max))
+      testStochasticAverage(Int32.random(in: .min ... .max))
+      testStochasticAverage(UInt8.random(in: .min ... .max))
+      testStochasticAverage(UInt16.random(in: .min ... .max))
+      testStochasticAverage(UInt32.random(in: .min ... .max))
+      testStochasticAverage(Int64.random(in: .min ... .max))
+      testStochasticAverage(UInt64.random(in: .min ... .max))
+      if #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) {
+        testStochasticAverage(Int128.random(in: .min ... .max))
+        testStochasticAverage(UInt128.random(in: .min ... .max))
+      }
+      testStochasticAverage(DoubleWidth<Int64>.random(in: .min ... .max))
+      testStochasticAverage(DoubleWidth<UInt64>.random(in: .min ... .max))
+    }
   }
-  
-  func testStochasticShifts() {
-    testStochasticAverage(Int8.random(in: .min ... .max))
-    testStochasticAverage(Int16.random(in: .min ... .max))
-    testStochasticAverage(Int32.random(in: .min ... .max))
-    testStochasticAverage(UInt8.random(in: .min ... .max))
-    testStochasticAverage(UInt16.random(in: .min ... .max))
-    testStochasticAverage(UInt32.random(in: .min ... .max))
-    testStochasticAverage(Int64.random(in: .min ... .max))
-    testStochasticAverage(UInt64.random(in: .min ... .max))
-    testStochasticAverage(DoubleWidth<Int64>.random(in: .min ... .max))
-    testStochasticAverage(DoubleWidth<UInt64>.random(in: .min ... .max))
-  }
-}

--- a/Tests/IntegerUtilitiesTests/ShiftTests.swift
+++ b/Tests/IntegerUtilitiesTests/ShiftTests.swift
@@ -167,32 +167,6 @@ final class IntegerUtilitiesShiftTests: XCTestCase {
       testRoundingShift(UInt.self, rounding: .toNearestOrEven)
       testRoundingShift(UInt.self, rounding: .toOdd)
       testRoundingShift(UInt.self, rounding: .stochastically)
-      
-      if #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) {
-        testRoundingShift(Int128.self, rounding: .down)
-        testRoundingShift(Int128.self, rounding: .up)
-        testRoundingShift(Int128.self, rounding: .towardZero)
-        testRoundingShift(Int128.self, rounding: .awayFromZero)
-        testRoundingShift(Int128.self, rounding: .toNearestOrUp)
-        testRoundingShift(Int128.self, rounding: .toNearestOrDown)
-        testRoundingShift(Int128.self, rounding: .toNearestOrZero)
-        testRoundingShift(Int128.self, rounding: .toNearestOrAway)
-        testRoundingShift(Int128.self, rounding: .toNearestOrEven)
-        testRoundingShift(Int128.self, rounding: .toOdd)
-        testRoundingShift(Int128.self, rounding: .stochastically)
-        
-        testRoundingShift(UInt128.self, rounding: .down)
-        testRoundingShift(UInt128.self, rounding: .up)
-        testRoundingShift(UInt128.self, rounding: .towardZero)
-        testRoundingShift(UInt128.self, rounding: .awayFromZero)
-        testRoundingShift(UInt128.self, rounding: .toNearestOrUp)
-        testRoundingShift(UInt128.self, rounding: .toNearestOrDown)
-        testRoundingShift(UInt128.self, rounding: .toNearestOrZero)
-        testRoundingShift(UInt128.self, rounding: .toNearestOrAway)
-        testRoundingShift(UInt128.self, rounding: .toNearestOrEven)
-        testRoundingShift(UInt128.self, rounding: .toOdd)
-        testRoundingShift(UInt128.self, rounding: .stochastically)
-      }
     }
     
     // Stochastic rounding doesn't have a deterministic "expected" answer,
@@ -247,10 +221,6 @@ final class IntegerUtilitiesShiftTests: XCTestCase {
       testStochasticAverage(UInt32.random(in: .min ... .max))
       testStochasticAverage(Int64.random(in: .min ... .max))
       testStochasticAverage(UInt64.random(in: .min ... .max))
-      if #available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *) {
-        testStochasticAverage(Int128.random(in: .min ... .max))
-        testStochasticAverage(UInt128.random(in: .min ... .max))
-      }
       testStochasticAverage(DoubleWidth<Int64>.random(in: .min ... .max))
       testStochasticAverage(DoubleWidth<UInt64>.random(in: .min ... .max))
     }


### PR DESCRIPTION
These were omitted in the first pass over integer rounding rules, but are generally useful and make good sense to have available. In particular, toNearestOrUp is the natural mode for a lot of fixed-point arithmetic, and frequently has HW support on SIMD units, so it makes good sense to have a name for that. Once you add that, having nearestOrDown also makes sense, and then nearestOrZero should exist by analogy to nearestOrAway. Also beefed up testing and refactored the division rounding code somewhat.

Also renamed `toNearestOrAwayFromZero` to `toNearestOrAway` for symmetry. The original name was never released, but we'll keep it around in deprecated form anyway.