### PR TITLE
Add extern "C" to shim header file

### DIFF
--- a/Sources/_NumericsShims/include/_NumericsShims.h
+++ b/Sources/_NumericsShims/include/_NumericsShims.h
@@ -9,6 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HEADER_SHIM static inline __attribute__((__always_inline__))
 
 // This header uses most of the libm functions, but we don't want to end up
@@ -450,3 +454,7 @@ HEADER_SHIM void _numerics_optimization_barrier(const void *pointer) {
 }
 
 #undef CLANG_RELAX_FP
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adding this allows this package to be used with C++ interop enabled.

Otherwise, building a package that depends on this leads to linker
errors.

rdar://113756245
