### PR TITLE
add ElementaryFunctions conformance to SIMD types

### DIFF
--- a/Sources/RealModule/SIMD+ElementaryFunctions.swift
+++ b/Sources/RealModule/SIMD+ElementaryFunctions.swift
@@ -1,16 +1,3 @@
-extension SIMD2: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-extension SIMD4: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-extension SIMD8: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-extension SIMD16: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-extension SIMD32: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-extension SIMD64: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
-
-extension SIMD2: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
-extension SIMD4: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
-extension SIMD8: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
-extension SIMD16: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
-extension SIMD32: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
-extension SIMD64: ElementaryFunctions where Scalar: ElementaryFunctions & FloatingPoint { }
 
 extension SIMD where Scalar: ElementaryFunctions {
     @_transparent

--- a/Sources/RealModule/SIMD+RealFunctions.swift
+++ b/Sources/RealModule/SIMD+RealFunctions.swift
@@ -1,6 +1,7 @@
 
-// Unfortunately we can't conform concrete simd types to `RealFunctions` as we can't implement a simd equivalent of
+// All `RealFunctions` implementations are here except for
 // `static func signGamma(_ x: Self) -> FloatingPointSign`
+// as SIMD can't work with `FloatingPointSign`
 extension SIMD where Scalar: RealFunctions {
     @_transparent
     public static func atan2(y: Self, x: Self) -> Self {


### PR DESCRIPTION
Adresses #103 
There's a few parts that probably require discussion. 

`ElementaryFunctions` requires conformance to `AdditiveArithmetic`
The concrete SIMD2, 4, etc types from the standard library have a conformance to `AdditiveArithmetic` defined in the Differentiation module so this conformance is only visible when `_Differentiation` is imported. 
It's defined [as follows](https://github.com/swiftlang/swift/blob/04726c04e3f112ff74a3d953fefe40d9c761734b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb#L26C1-L27C1): `extension SIMD${n}: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}`

In some of our code that would be used with swift toolchains both with and without access to the `_Differentiation` module we'd get around this by using the following:
```swift
#if canImport(_Differentiation)
import _Differentiation
#endif

#if !canImport(_Differentiation)
// add `AdditiveArithmetic` conformance since this is only present in the _Differentiation module which is not present everywhere
extension SIMD2: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
extension SIMD4: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
extension SIMD8: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
extension SIMD16: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
extension SIMD32: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
extension SIMD64: @retroactive AdditiveArithmetic where Scalar: FloatingPoint {}
#endif
```

My main worry here is that the conformance to `AdditiveArithmetic` in the standard library will conflict with the one provided here. Either the full one or the one that's limited to types conforming to `FloatingPoint`. But as far as I understand this should be ok due to the `@retroactive` attribute. 

Furthermore, technically we could be more generic (here and in the stdlib _Differentiation module) by requiring `Scalar` to conform to just `AdditiveArithmetic` but that would require more boilerplate, now we get the implementation [for free from the standard library](https://github.com/swiftlang/swift/blob/04726c04e3f112ff74a3d953fefe40d9c761734b/stdlib/public/core/SIMDVector.swift#L871). The other solution is more complete however and would look something like: 

```swift
extension SIMD2: @retroactive AdditiveArithmetic where Scalar: AdditiveArithmetic {
    @_transparent
    public static var zero: SIMD2<Scalar> {
        Self()
    }
    
    @_transparent
    public static func + (lhs: SIMD2<Scalar>, rhs: SIMD2<Scalar>) -> SIMD2<Scalar> {
        var v = Self()
        for i in v.indices {
            v[i] = lhs[i] + rhs[i]
        }
        return v
    }
    
    @_transparent
    public static func - (lhs: SIMD2<Scalar>, rhs: SIMD2<Scalar>) -> SIMD2<Scalar> {
        var v = Self()
        for i in v.indices {
            v[i] = lhs[i] - rhs[i]
        }
        return v
    }
}
```

Ideally the `AdditiveArithmetic` conformance would live in the stdlib itself. That way none of the Differentiation code would break and there's no longer the need for this duplication. But I'm not sure if just a "completeness" argument warrants that change.

Aside from the above I also added implementations for most of the `RealFunction` except for `static func signGamma(_ x: Self) -> FloatingPointSign` since it can't implemented for simd types. So unfortunately we can't conform the simdtypes to the protocol. 

Let me know your thoughts/questions!