### PR TITLE
[1.1] Enable relaxed f16 arithmetic for x86

### DIFF
--- a/Sources/RealModule/Float16+Real.swift
+++ b/Sources/RealModule/Float16+Real.swift
@@ -173,9 +173,6 @@ extension Float16: Real {
   }
   #endif
   
-  // TODO: once clang stabilizes the calling conventions for _Float16 on Intel,
-  // we can re-enable these; presently the type is disabled on the target.
-  #if !(arch(i386) || arch(x86_64))
   @_transparent
   public static func _relaxedAdd(_ a: Float16, _ b: Float16) -> Float16 {
     _numerics_relaxed_addf16(a, b)
@@ -185,7 +182,6 @@ extension Float16: Real {
   public static func _relaxedMul(_ a: Float16, _ b: Float16) -> Float16 {
     _numerics_relaxed_mulf16(a, b)
   }
-  #endif
 }
 
 #endif

--- a/Sources/_NumericsShims/include/_NumericsShims.h
+++ b/Sources/_NumericsShims/include/_NumericsShims.h
@@ -389,7 +389,6 @@ HEADER_SHIM long double libm_lgammal(long double x, int *signp) {
 // MARK: - math inlines with relaxed semantics to support optimization.
 #define CLANG_RELAX_FP _Pragma("clang fp reassociate(on) contract(fast)")
 
-#if !(__i386__ || __x86_64__)
 /// a + b with the "allow reassociation" and "allow FMA formation" flags
 /// set in the IR.
 HEADER_SHIM _Float16 _numerics_relaxed_addf16(_Float16 a, _Float16 b) {
@@ -403,7 +402,6 @@ HEADER_SHIM _Float16 _numerics_relaxed_mulf16(_Float16 a, _Float16 b) {
   CLANG_RELAX_FP
   return a * b;
 }
-#endif
 
 /// a + b with the "allow reassociation" and "allow FMA formation" flags
 /// set in the IR.


### PR DESCRIPTION
The ABI is stable, so these operations can be turned on.