### PR TITLE
Constrain AlgebraicField to required Magnitude:AlgebraicField

### DIFF
--- a/Sources/RealModule/AlgebraicField.swift
+++ b/Sources/RealModule/AlgebraicField.swift
@@ -40,7 +40,7 @@
 /// See also `Real`, `SignedNumeric`, `Numeric` and `AdditiveArithmetic`.
 ///
 /// [field]: https://en.wikipedia.org/wiki/Field_(mathematics)
-public protocol AlgebraicField: SignedNumeric {
+public protocol AlgebraicField: SignedNumeric where Magnitude: AlgebraicField {
   
   /// Replaces a with the (approximate) quotient `a/b`.
   static func /=(a: inout Self, b: Self)


### PR DESCRIPTION
This is formally a source-breaking change. However it is expected to not be source-breaking in practice, because any conforming type either has a real magnitude (in the case of real or complex types), which would necessarily have to support all the AF operations to implement the type, or is perhaps a finite field with a bogus stand-in Magnitude.