### PR TITLE
Disable Swift 5.9 testing on Windows for now

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,8 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main


### PR DESCRIPTION
That docker image seems to be broken, so it's all false positives.