### PR TITLE
Support Embedded Swift

### DIFF
--- a/Sources/ComplexModule/Complex+Codable.swift
+++ b/Sources/ComplexModule/Complex+Codable.swift
@@ -12,6 +12,7 @@
 import RealModule
 
 // FloatingPoint does not refine Codable, so this is a conditional conformance.
+@_unavailableInEmbedded
 extension Complex: Decodable where RealType: Decodable {
   public init(from decoder: Decoder) throws {
     var unkeyedContainer = try decoder.unkeyedContainer()
@@ -21,6 +22,7 @@ extension Complex: Decodable where RealType: Decodable {
   }
 }
 
+@_unavailableInEmbedded
 extension Complex: Encodable where RealType: Encodable {
   public func encode(to encoder: Encoder) throws {
     var unkeyedContainer = encoder.unkeyedContainer()

--- a/Sources/ComplexModule/Complex+StringConvertible.swift
+++ b/Sources/ComplexModule/Complex+StringConvertible.swift
@@ -16,6 +16,7 @@ extension Complex: CustomStringConvertible {
   }
 }
 
+@_unavailableInEmbedded
 extension Complex: CustomDebugStringConvertible {
   public var debugDescription: String {
     "Complex<\(RealType.self)>(\(String(reflecting: x)), \(String(reflecting: y)))"


### PR DESCRIPTION
I'd like to be able to use Swift Numerics with code targeting the Embedded mode.
Excluding those 3 extensions allowed me to include the package and use ComplexModule in some code deployed to an STM32 board.