### PR TITLE
Skip Float80 overflow/underflow tests on FreeBSD

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,7 @@ jobs:
       windows_exclude_swift_versions: '[{"swift_version": "5.9"}]'
       enable_wasm_sdk_build: true
       wasm_sdk_build_command: swift build --target Numerics
+      enable_freebsd_checks: true
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Tests/RealTests/IntegerExponentTests.swift
+++ b/Tests/RealTests/IntegerExponentTests.swift
@@ -31,6 +31,11 @@ internal extension Real where Self: FixedWidthFloatingPoint {
     XCTAssertEqual(Self.pow(-1,  Int.max), -1)
     XCTAssertEqual(Self.pow(-1, -Int.max), -1)
     XCTAssertEqual(Self.pow(-1,  Int.min),  1)
+  }
+
+  static func testIntegerExponentOverflowAndUnderflow() {
+    // TODO: replace with seedable generator, print seed.
+    var g = SystemRandomNumberGenerator()
     // Generate some random test values that definitely overflow or
     // underflow; we want to be sure that we get the right ±0 or ±∞
     // result.
@@ -82,6 +87,7 @@ internal extension Real where Self: FixedWidthFloatingPoint {
 extension Float16 {
   static func testIntegerExponent() {
     testIntegerExponentCommon()
+    testIntegerExponentOverflowAndUnderflow()
     testIntegerExponentDoubleAndSmaller()
     let u = Float16(1).nextUp
     let d = Float16(1).nextDown
@@ -109,6 +115,7 @@ extension Float16 {
 extension Float {
   static func testIntegerExponent() {
     testIntegerExponentCommon()
+    testIntegerExponentOverflowAndUnderflow()
     testIntegerExponentDoubleAndSmaller()
     let u = Float(1).nextUp
     let d = Float(1).nextDown
@@ -135,6 +142,7 @@ extension Float {
 extension Double {
   static func testIntegerExponent() {
     testIntegerExponentCommon()
+    testIntegerExponentOverflowAndUnderflow()
     // Following tests only make sense (and are only necessary) on 64b platforms.
 #if arch(arm64) || arch(x86_64)
     testIntegerExponentDoubleAndSmaller()
@@ -193,6 +201,10 @@ final class IntegerExponentTests: XCTestCase {
   #if (arch(i386) || arch(x86_64)) && !os(Windows) && !os(Android)
   func testFloat80() {
     Float80.testIntegerExponentCommon()
+    // FreeBSD's powl(3) has a bug where a minus sign is not perserved on overflow/underflow.
+    #if !os(FreeBSD)
+    Float80.testIntegerExponentOverflowAndUnderflow()
+    #endif
   }
   #endif
 }


### PR DESCRIPTION
closes #333 

This is a workaround for [a bug in FreeBSD's `powl`](https://github.com/apple/swift-numerics/issues/333#issuecomment-3805135548).

Changes:

1. Split `testIntegerExponentCommon()` into `testIntegerExponentCommon()` and `testIntegerExponentOverflowAndUnderflow()`.
2. Skip `testIntegerExponentOverflowAndUnderflow()` in `testFloat80()` if the OS is FreeBSD.
3. Enable FreeBSD CI